### PR TITLE
Improve README for mediawiki_api_call_helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ Features:
   exception)
 * Checks automatically if the correct item has been loaded by comparing it to the data provided
 * All Wikibase data types implemented
-* A dedicated ItemEngine.write() method allows loading and consistency checks of data before any write to Wikibase is
-  performed
+* A dedicated wbi_core.ItemEngine.write() method allows loading and consistency checks of data before any write to
+  Wikibase is performed
 * Full access to the whole Wikibase item as a JSON document
 
 There are two ways of working with Wikibase items:
@@ -148,9 +148,9 @@ login_instance = wbi_login.Login(user='<bot user name>', pwd='<bot password>')
 
 The Wikimedia universe currently only support authentication via OAuth1. If WBI should be used as a backend for a
 webapp, the bot should use OAuth for authentication, WBI supports this, you just need to specify consumer key and
-consumer secret when instantiating wbi_login.Login. In contrast to username and password login, OAuth is a 2 steps
-process as manual user confirmation for OAuth login is required. This means that the method continue_oauth() needs to be
-called after creating the wbi_login.Login instance.
+consumer secret when instantiating `wbi_login.Login`. In contrast to username and password login, OAuth is a 2 steps
+process as manual user confirmation for OAuth login is required. This means that the
+method `wbi_login.Login.continue_oauth()` needs to be called after creating the `wbi_login.Login` instance.
 
 Example:
 
@@ -161,9 +161,9 @@ login_instance = wbi_login.Login(consumer_key='<your_consumer_key>', consumer_se
 login_instance.continue_oauth()
 ```
 
-The method continue_oauth() will either prompt the user for a callback URL (normal bot runs), or it will take a
-parameter so in the case of WBI being used as a backend for e.g. a web app, where the callback will provide the
-authentication information directly to the backend and so no copy and paste of the callback URL is required.
+The method `wbi_login.Login.continue_oauth()` will either prompt the user for a callback URL (normal bot runs), or it
+will take a parameter so in the case of WBI being used as a backend for e.g. a web app, where the callback will provide
+the authentication information directly to the backend and so no copy and paste of the callback URL is required.
 
 ## Wikibase Data Types ##
 
@@ -241,7 +241,7 @@ option dict_id_label to return a dict of item id and label as a result.
 ## Merge Wikibase items ##
 
 Sometimes, Wikibase items need to be merged. An API call exists for that, and wbi_core implements a method accordingly.
-`wbi_core.FunctionsEngine.merge_items` takes five arguments:
+`wbi_core.FunctionsEngine.merge_items()` takes five arguments:
 the QID of the item which should be merged into another item (from_id), the QID of the item the first item should be
 merged into (to_id), a login object of type wbi_login.Login to provide the API call with the required authentication
 information, a server (mediawiki_api_url) if the Wikibase instance is not Wikidata and a flag for ignoring merge

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@
 - [Helper Methods](#helper-methods)
     - [Execute SPARQL queries](#execute-sparql-queries)
     - [Use Mediawiki API](#use-mediawiki-api)
-        - [Example](#example)
     - [Wikidata Search](#wikidata-search)
     - [Merge Wikibase items](#merge-wikibase-items)
 - [Examples (in "normal" mode)](#examples-in-normal-mode)
@@ -213,7 +212,7 @@ takes a mandatory data array (data) and multiple optionals parameters like a log
 mediawiki_api_url string if the Mediawiki is not Wikidata, a user_agent string to set a custom HTTP User Agent header,
 and an allow_anonymous boolean to force authentication.
 
-### Example ###
+Example:
 
 Retrieve last 10 revisions from Wikidata element Q2 (Earth):
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![PyPi](https://img.shields.io/pypi/v/wikibaseintegrator.svg)](https://pypi.python.org/pypi/wikibaseintegrator)
 
 - [WikibaseIntegrator / WikidataIntegrator](#wikibaseintegrator--wikidataintegrator)
-- [WikibaseIntegrator / WikidataIntegrator](#wikibaseintegrator--wikidataintegrator)
 - [Installation](#installation)
 - [Using a Wikibase instance](#using-a-wikibase-instance)
 - [The Core Parts](#the-core-parts)

--- a/README.md
+++ b/README.md
@@ -6,22 +6,25 @@
 [![PyPi](https://img.shields.io/pypi/v/wikibaseintegrator.svg)](https://pypi.python.org/pypi/wikibaseintegrator)
 
 - [WikibaseIntegrator / WikidataIntegrator](#wikibaseintegrator--wikidataintegrator)
+- [WikibaseIntegrator / WikidataIntegrator](#wikibaseintegrator--wikidataintegrator)
 - [Installation](#installation)
 - [Using a Wikibase instance](#using-a-wikibase-instance)
 - [The Core Parts](#the-core-parts)
-    * [wbi_core.ItemEngine](#wbi_coreitemengine)
-    * [wbi_core.FunctionsEngine](#wbi_corefunctionsengine)
-    * [wbi_login.Login](#wbi_loginlogin)
-        + [Login with a username and a password](#login-with-a-username-and-a-password)
-        + [Login using OAuth1](#login-using-oauth1)
-    * [Wikibase Data Types](#wikibase-data-types)
+    - [wbi_core.ItemEngine](#wbi_coreitemengine)
+    - [wbi_core.FunctionsEngine](#wbi_corefunctionsengine)
+    - [wbi_login.Login](#wbi_loginlogin)
+        - [Login with a username and a password](#login-with-a-username-and-a-password)
+        - [Login using OAuth1](#login-using-oauth1)
+    - [Wikibase Data Types](#wikibase-data-types)
 - [Helper Methods](#helper-methods)
-    * [Execute SPARQL queries](#execute-sparql-queries)
-    * [Wikidata Search](#wikidata-search)
-    * [Merge Wikibase items](#merge-wikibase-items)
+    - [Execute SPARQL queries](#execute-sparql-queries)
+    - [Use Mediawiki API](#use-mediawiki-api)
+        - [Example](#example)
+    - [Wikidata Search](#wikidata-search)
+    - [Merge Wikibase items](#merge-wikibase-items)
 - [Examples (in "normal" mode)](#examples-in-normal-mode)
-    * [A Minimal Bot](#a-minimal-bot)
-    * [A Minimal Bot for Mass Import](#a-minimal-bot-for-mass-import)
+    - [A Minimal Bot](#a-minimal-bot)
+    - [A Minimal Bot for Mass Import](#a-minimal-bot-for-mass-import)
 - [Examples (in "fast run" mode)](#examples-in-fast-run-mode)
 
 # WikibaseIntegrator / WikidataIntegrator #
@@ -197,16 +200,40 @@ tuple, depending on the complexity of the data type.
 
 ## Execute SPARQL queries ##
 
-The method wbi_core.ItemEngine.execute_sparql_query() allows you to execute SPARQL queries without a hassle. It takes
+The method `wbi_core.ItemEngine.execute_sparql_query()` allows you to execute SPARQL queries without a hassle. It takes
 the actual query string (query), optional prefixes (prefix) if you do not want to use the standard prefixes of Wikidata,
 the actual entpoint URL (endpoint), and you can also specify a user agent for the http header sent to the SPARQL
 server (user_agent). The latter is very useful to let the operators of the endpoint know who you are, especially if you
 execute many queries on the endpoint. This allows the operators of the endpoint to contact you (e.g. specify an email
 address, or the URL to your bot code repository.)
 
+## Use Mediawiki API ##
+
+The method `wbi_core.FunctionsEngine.mediawiki_api_call_helper()` allows you to execute MediaWiki API POST call. It
+takes a mandatory data array (data) and multiple optionals parameters like a login object of type wbi_login.Login, a
+mediawiki_api_url string if the Mediawiki is not Wikidata, a user_agent string to set a custom HTTP User Agent header,
+and an allow_anonymous boolean to force authentication.
+
+### Example ###
+
+Retrieve last 10 revisions from Wikidata element Q2 (Earth):
+
+```python
+from wikibaseintegrator import wbi_core
+
+query = {
+    'action': 'query',
+    'prop': 'revisions',
+    'titles': 'Q2',
+    'rvlimit': 10
+}
+
+print(wbi_core.FunctionsEngine.mediawiki_api_call_helper(query, allow_anonymous=True))
+```
+
 ## Wikidata Search ##
 
-The method wbi_core.ItemEngine.get_search_results() allows for string search in a Wikibase instance. This means that
+The method `wbi_core.ItemEngine.get_search_results()` allows for string search in a Wikibase instance. This means that
 labels, descriptions and aliases can be searched for a string of interest. The method takes five arguments: The actual
 search string (search_string), an optional server (mediawiki_api_url, in case the Wikibase instance used is not
 Wikidata), an optional user_agent, an optional max_results (default 500), an optional language (default 'en'), and an
@@ -215,9 +242,9 @@ option dict_id_label to return a dict of item id and label as a result.
 ## Merge Wikibase items ##
 
 Sometimes, Wikibase items need to be merged. An API call exists for that, and wbi_core implements a method accordingly.
-`wbi_core.FunctionsEngine.merge_items(from_id, to_id, login_obj)` takes five arguments:
+`wbi_core.FunctionsEngine.merge_items` takes five arguments:
 the QID of the item which should be merged into another item (from_id), the QID of the item the first item should be
-merged into (to_id), a login object of type wbi_login.Login() to provide the API call with the required authentication
+merged into (to_id), a login object of type wbi_login.Login to provide the API call with the required authentication
 information, a server (mediawiki_api_url) if the Wikibase instance is not Wikidata and a flag for ignoring merge
 conflicts (ignore_conflicts). The last parameter will do a partial merge for all statements which do not conflict. This
 should generally be avoided because it leaves a crippled item in Wikibase. Before a merge, any potential conflicts

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - [Helper Methods](#helper-methods)
     - [Execute SPARQL queries](#execute-sparql-queries)
     - [Use Mediawiki API](#use-mediawiki-api)
-    - [Wikidata Search](#wikidata-search)
+    - [Wikibase search entities](#wikibase-search-entities)
     - [Merge Wikibase items](#merge-wikibase-items)
 - [Examples (in "normal" mode)](#examples-in-normal-mode)
     - [A Minimal Bot](#a-minimal-bot)
@@ -229,7 +229,7 @@ query = {
 print(wbi_core.FunctionsEngine.mediawiki_api_call_helper(query, allow_anonymous=True))
 ```
 
-## Wikidata Search ##
+## Wikibase search entities ##
 
 The method `wbi_core.ItemEngine.get_search_results()` allows for string search in a Wikibase instance. This means that
 labels, descriptions and aliases can be searched for a string of interest. The method takes five arguments: The actual

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -14,15 +14,13 @@ __license__ = 'AGPLv3'
 class TestMediawikiApiCall(unittest.TestCase):
     def test_all(self):
         with self.assertRaises(MWApiError):
-            wbi_core.FunctionsEngine.mediawiki_api_call_helper(data={'format': 'json', 'action': 'wbgetentities', 'ids': 'Q42'},
-                                                               mediawiki_api_url="http://www.wikidataaaaaaa.org", max_retries=3, retry_after=1,
-                                                               allow_anonymous=True)
+            wbi_core.FunctionsEngine.mediawiki_api_call_helper(data={'format': 'json', 'action': 'wbgetentities', 'ids': 'Q42'}, mediawiki_api_url="http://www.wikidataaaaaaa.org",
+                                                               max_retries=3, retry_after=1, allow_anonymous=True)
         with self.assertRaises(requests.HTTPError):
-            wbi_core.FunctionsEngine.mediawiki_api_call_helper(data=None, mediawiki_api_url="http://httpbin.org/status/400", max_retries=3, retry_after=1,
-                                                               allow_anonymous=True)
+            wbi_core.FunctionsEngine.mediawiki_api_call_helper(data=None, mediawiki_api_url="http://httpbin.org/status/400", max_retries=3, retry_after=1, allow_anonymous=True)
 
-        test = wbi_core.FunctionsEngine.mediawiki_api_call_helper(data={'format': 'json', 'action': 'wbgetentities', 'ids': 'Q42'}, max_retries=3,
-                                                                  retry_after=1, allow_anonymous=True)
+        test = wbi_core.FunctionsEngine.mediawiki_api_call_helper(data={'format': 'json', 'action': 'wbgetentities', 'ids': 'Q42'}, max_retries=3, retry_after=1,
+                                                                  allow_anonymous=True)
         print(test)
 
 

--- a/wikibaseintegrator/wbi_core.py
+++ b/wikibaseintegrator/wbi_core.py
@@ -1012,6 +1012,44 @@ class FunctionsEngine(object):
         return json_data
 
     @staticmethod
+    def mediawiki_api_call_helper(data, login=None, mediawiki_api_url=None, user_agent=None, allow_anonymous=False, max_retries=1000, retry_after=60):
+        mediawiki_api_url = config['MEDIAWIKI_API_URL'] if mediawiki_api_url is None else mediawiki_api_url
+        user_agent = config['USER_AGENT_DEFAULT'] if user_agent is None else user_agent
+
+        if not allow_anonymous:
+            if login is None:
+                # Force allow_anonymous as False by default to ask for a login object
+                raise ValueError('allow_anonymous can\'t be False and login is None at the same time.')
+            elif mediawiki_api_url != login.mediawiki_api_url:
+                raise ValueError('mediawiki_api_url can\'t be different with the one in the login object.')
+
+        headers = {
+            'User-Agent': user_agent
+        }
+
+        if data is not None:
+            # format can only be json when using mediawiki_api_call()
+            if 'format' not in data:
+                data.update({'format': 'json'})
+
+            if login is not None and 'token' not in data:
+                data.update({'token': login.get_edit_token()})
+
+            if not allow_anonymous:
+                # Always assert user if allow_anonymous is False
+                if 'assert' not in data:
+                    data.update({'assert': 'user'})
+                if 'token' in data and data['token'] == '+\\':
+                    raise wbi_login.LoginError('Anonymous edit are not allowed by default. Set allow_anonymous to True to edit mediawiki anonymously.')
+            elif 'assert' not in data:
+                # Always assert anon if allow_anonymous is True
+                data.update({'assert': 'anon'})
+
+        login_session = login.get_session() if login is not None else None
+
+        return FunctionsEngine.mediawiki_api_call('POST', mediawiki_api_url, login_session, data=data, headers=headers, max_retries=max_retries, retry_after=retry_after)
+
+    @staticmethod
     @wbi_backoff()
     def execute_sparql_query(query, prefix=None, endpoint=None, user_agent=None, as_dataframe=False, max_retries=1000, retry_after=60, debug=False):
         """
@@ -1112,29 +1150,6 @@ class FunctionsEngine(object):
                 if link["title"].startswith("Q"):
                     linkedby.append(link["title"])
         return linkedby
-
-    @staticmethod
-    def mediawiki_api_call_helper(data, login=None, mediawiki_api_url=None, user_agent=None, allow_anonymous=False, max_retries=1000, retry_after=60):
-        mediawiki_api_url = config['MEDIAWIKI_API_URL'] if mediawiki_api_url is None else mediawiki_api_url
-        user_agent = config['USER_AGENT_DEFAULT'] if user_agent is None else user_agent
-
-        if login is not None and allow_anonymous is not True and mediawiki_api_url != login.mediawiki_api_url:
-            raise ValueError('mediawiki_api_url can\'t be different with the one in the login object.')
-
-        headers = {
-            'User-Agent': user_agent
-        }
-
-        if data is not None and not allow_anonymous:
-            if 'token' in data and data['token'] == '+\\':
-                raise wbi_login.LoginError('Anonymous edit are not allowed by default. Set allow_anonymous to True to edit mediawiki anonymously.')
-            else:
-                data.update({'assert': 'user'})
-
-        login_session = login.get_session() if login is not None else None
-
-        return FunctionsEngine.mediawiki_api_call('POST', mediawiki_api_url, login_session, data=data, headers=headers, max_retries=max_retries,
-                                                  retry_after=retry_after)
 
     @staticmethod
     def merge_items(from_id, to_id, login, ignore_conflicts='', mediawiki_api_url=None, user_agent=None, allow_anonymous=False):


### PR DESCRIPTION
* Force format to 'json' (because mediawiki_api_call only accept this as result)
* Assert anon if allow_anonymous is set to True
* Raise an exception if allow_anonymous is False without a login object
* Add the token to all requests if a login object is provided