### PR TITLE
Only reset specific language when replacing description

### DIFF
--- a/wikibaseintegrator/wbi_core.py
+++ b/wikibaseintegrator/wbi_core.py
@@ -515,8 +515,8 @@ class ItemEngine(object):
             else:
                 return
 
-        if 'descriptions' not in self.json_representation or not self.json_representation['descriptions'] or if_exists == 'REPLACE':
-            self.json_representation['descriptions'][lang] = {}
+        if 'descriptions' not in self.json_representation or not self.json_representation['descriptions']:
+                self.json_representation['descriptions'] = {}
 
         self.json_representation['descriptions'][lang] = {
             'language': lang,

--- a/wikibaseintegrator/wbi_core.py
+++ b/wikibaseintegrator/wbi_core.py
@@ -516,7 +516,7 @@ class ItemEngine(object):
                 return
 
         if 'descriptions' not in self.json_representation or not self.json_representation['descriptions']:
-                self.json_representation['descriptions'] = {}
+            self.json_representation['descriptions'] = {}
 
         self.json_representation['descriptions'][lang] = {
             'language': lang,

--- a/wikibaseintegrator/wbi_core.py
+++ b/wikibaseintegrator/wbi_core.py
@@ -516,7 +516,7 @@ class ItemEngine(object):
                 return
 
         if 'descriptions' not in self.json_representation or not self.json_representation['descriptions'] or if_exists == 'REPLACE':
-            self.json_representation['descriptions'] = {}
+            self.json_representation['descriptions'][lang] = {}
 
         self.json_representation['descriptions'][lang] = {
             'language': lang,


### PR DESCRIPTION
At the moment it is not possible to set descriptions in different languages, because if REPLACE is set, it will reset the descriptions for all languages.