### PR TITLE
Support NonUniqueLabelDescriptionPairError in mediawiki_api_call()

### DIFF
--- a/wikibaseintegrator/wbi_exceptions.py
+++ b/wikibaseintegrator/wbi_exceptions.py
@@ -30,7 +30,7 @@ class NonUniqueLabelDescriptionPairError(MWApiError):
         """
         qid_string = self.error_msg['error']['messages'][0]['parameters'][2]
 
-        return qid_string.split('|')[0][2:]
+        return str(qid_string.split('|')[0][2:])
 
     def __str__(self):
         return repr(self.error_msg)

--- a/wikibaseintegrator/wbi_helpers.py
+++ b/wikibaseintegrator/wbi_helpers.py
@@ -113,14 +113,14 @@ def mediawiki_api_call(method: str, mediawiki_api_url: str = None, session: Sess
             # non-existent error
             if 'code' in json_data['error'] and json_data['error']['code'] in ['no-such-entity', 'missingtitle']:
                 if 'info' in json_data['error']['code']:
-                    raise NonExistentEntityError(json_data['error']['code']['info'])
+                    raise NonExistentEntityError(json_data)
                 raise NonExistentEntityError()
 
             # duplicate error
             if 'code' in json_data['error'] and json_data['error']['code'] == 'modification-failed' and any(
                     obj['name'] == 'wikibase-validator-label-with-description-conflict' for obj in json_data['error']['messages']):  # pragma: no cover
                 if 'info' in json_data['error']:
-                    raise NonUniqueLabelDescriptionPairError(json_data['error']['info'])
+                    raise NonUniqueLabelDescriptionPairError(json_data)
                 raise NonUniqueLabelDescriptionPairError(response.json() if response else {})
 
             # others case

--- a/wikibaseintegrator/wbi_helpers.py
+++ b/wikibaseintegrator/wbi_helpers.py
@@ -117,8 +117,11 @@ def mediawiki_api_call(method: str, mediawiki_api_url: str = None, session: Sess
                 raise NonExistentEntityError()
 
             # duplicate error
-            if 'code' in json_data['error'] and json_data['error']['code'] in ['modification-failed', 'wikibase-validator-label-with-description-conflict']:  # pragma: no cover
-                raise NonUniqueLabelDescriptionPairError(response.json())
+            if 'code' in json_data['error'] and json_data['error']['code'] == 'modification-failed' and any(
+                    obj['name'] == 'wikibase-validator-label-with-description-conflict' for obj in json_data['error']['messages']):  # pragma: no cover
+                if 'info' in json_data['error']:
+                    raise NonUniqueLabelDescriptionPairError(json_data['error']['info'])
+                raise NonUniqueLabelDescriptionPairError(response.json() if response else {})
 
             # others case
             raise MWApiError(response.json() if response else {})

--- a/wikibaseintegrator/wbi_helpers.py
+++ b/wikibaseintegrator/wbi_helpers.py
@@ -11,7 +11,7 @@ from requests import Session
 
 from wikibaseintegrator.wbi_backoff import wbi_backoff
 from wikibaseintegrator.wbi_config import config
-from wikibaseintegrator.wbi_exceptions import MWApiError, NonExistentEntityError, SearchError
+from wikibaseintegrator.wbi_exceptions import MWApiError, NonExistentEntityError, NonUniqueLabelDescriptionPairError, SearchError
 
 if TYPE_CHECKING:
     from wikibaseintegrator.entities.baseentity import BaseEntity
@@ -115,6 +115,10 @@ def mediawiki_api_call(method: str, mediawiki_api_url: str = None, session: Sess
                 if 'info' in json_data['error']['code']:
                     raise NonExistentEntityError(json_data['error']['code']['info'])
                 raise NonExistentEntityError()
+
+            # duplicate error
+            if 'code' in json_data['error'] and json_data['error']['code'] in ['modification-failed', 'wikibase-validator-label-with-description-conflict']:  # pragma: no cover
+                raise NonUniqueLabelDescriptionPairError(response.json())
 
             # others case
             raise MWApiError(response.json() if response else {})


### PR DESCRIPTION
Raise NonUniqueLabelDescriptionPairError also when the code in ['modification-failed', 'wikibase-validator-label-with-description-conflict']