### PR TITLE
Allow LIDs as values of properties

### DIFF
--- a/wikibaseintegrator/datatypes/item.py
+++ b/wikibaseintegrator/datatypes/item.py
@@ -1,3 +1,8 @@
+import re
+from typing import Any, Optional, Union
+
+from wikibaseintegrator.datatypes.basedatatype import BaseDataType
+
 class Item(BaseDataType):
     """
     Implements the Wikibase data type 'wikibase-item' with a value being another item ID

--- a/wikibaseintegrator/datatypes/item.py
+++ b/wikibaseintegrator/datatypes/item.py
@@ -3,6 +3,7 @@ from typing import Any, Optional, Union
 
 from wikibaseintegrator.datatypes.basedatatype import BaseDataType
 
+
 class Item(BaseDataType):
     """
     Implements the Wikibase data type 'wikibase-item' with a value being another item ID

--- a/wikibaseintegrator/datatypes/item.py
+++ b/wikibaseintegrator/datatypes/item.py
@@ -31,7 +31,7 @@ class Item(BaseDataType):
 
         if value:
             if isinstance(value, str):
-                pattern = re.compile(r'^(?:[a-zA-Z]+:)?(Q|L)?([0-9]+)$')
+                pattern = re.compile(r'^(?:[a-zA-Z]+:|.+\/entity\/)?(Q|L)?([0-9]+)$')
                 matches = pattern.match(value)
 
                 if not matches:

--- a/wikibaseintegrator/datatypes/item.py
+++ b/wikibaseintegrator/datatypes/item.py
@@ -35,7 +35,7 @@ class Item(BaseDataType):
                 matches = pattern.match(value)
 
                 if not matches:
-                    raise ValueError(f"Invalid item ID ({value}), format must be 'Q[0-9]+'")
+                    raise ValueError(f"Invalid item ID ({value}), format must be 'Q[0-9]+' or 'L[0-9]+'")
                 thetype=matches.group(1)
                 value = int(matches.group(2))
 

--- a/wikibaseintegrator/datatypes/item.py
+++ b/wikibaseintegrator/datatypes/item.py
@@ -43,7 +43,7 @@ class Item(BaseDataType):
                 'value': {
                     'entity-type': 'item',
                     'numeric-id': value,
-                    'id': f'{value}'
+                    'id': value
                 },
                 'type': 'wikibase-entityid'
             }

--- a/wikibaseintegrator/datatypes/item.py
+++ b/wikibaseintegrator/datatypes/item.py
@@ -31,19 +31,19 @@ class Item(BaseDataType):
 
         if value:
             if isinstance(value, str):
-                pattern = re.compile(r'^(?:[a-zA-Z]+:|.+\/entity\/)?(Q|L)?([0-9]+)$')
+                pattern = re.compile(r'^(?:[a-zA-Z]+:|.+\/entity\/)?((?:Q|L)[0-9]+)$')
                 matches = pattern.match(value)
 
                 if not matches:
                     raise ValueError(f"Invalid item ID ({value}), format must be 'Q[0-9]+' or 'L[0-9]+'")
-                thetype=matches.group(1)
-                value = int(matches.group(2))
+
+                value = int(matches.group(1))
 
             self.mainsnak.datavalue = {
                 'value': {
                     'entity-type': 'item',
                     'numeric-id': value,
-                    'id': f'{thetype}{value}'
+                    'id': f'{value}'
                 },
                 'type': 'wikibase-entityid'
             }

--- a/wikibaseintegrator/datatypes/item.py
+++ b/wikibaseintegrator/datatypes/item.py
@@ -1,9 +1,3 @@
-import re
-from typing import Any, Optional, Union
-
-from wikibaseintegrator.datatypes.basedatatype import BaseDataType
-
-
 class Item(BaseDataType):
     """
     Implements the Wikibase data type 'wikibase-item' with a value being another item ID
@@ -31,19 +25,19 @@ class Item(BaseDataType):
 
         if value:
             if isinstance(value, str):
-                pattern = re.compile(r'^(?:[a-zA-Z]+:|.+\/entity\/)?Q?([0-9]+)$')
+                pattern = re.compile(r'^(?:[a-zA-Z]+:)?(Q|L)?([0-9]+)$')
                 matches = pattern.match(value)
 
                 if not matches:
                     raise ValueError(f"Invalid item ID ({value}), format must be 'Q[0-9]+'")
-
-                value = int(matches.group(1))
+                thetype=matches.group(1)
+                value = int(matches.group(2))
 
             self.mainsnak.datavalue = {
                 'value': {
                     'entity-type': 'item',
                     'numeric-id': value,
-                    'id': f'Q{value}'
+                    'id': f'{thetype}{value}'
                 },
                 'type': 'wikibase-entityid'
             }


### PR DESCRIPTION
There are specific properties in Wikidata, such as [root (P5920)](https://www.wikidata.org/wiki/Property:P5920), used for example here: https://www.wikidata.org/wiki/Lexeme:L1093781 which link a Lexeme to another Lexeme.
When creating Lexeme data with WikibaseIntegrator, the library allowed only a QID to be assigned to any property, so it was impossible to create these relations.

My solution is to modify the regular expression in datatypes/item.py, which works for me.
If this is a bug, I would be happy to contribute a fix with this pull request.