### PR TITLE
Improve get method in claims.py to avoid KeyError

### DIFF
--- a/wikibaseintegrator/models/claims.py
+++ b/wikibaseintegrator/models/claims.py
@@ -24,7 +24,13 @@ class Claims(BaseModel):
         self.__claims = claims
 
     def get(self, property: str) -> list[Claim]:
-        return self.claims[property]
+        if isinstance(property, int):
+            property = 'P' + str(property)
+
+        if property in self.claims:
+            return self.claims[property]
+
+        return []
 
     def remove(self, property: str | None = None) -> None:
         if property in self.claims:

--- a/wikibaseintegrator/models/claims.py
+++ b/wikibaseintegrator/models/claims.py
@@ -23,7 +23,7 @@ class Claims(BaseModel):
     def claims(self, claims: dict[str, list[Claim]]):
         self.__claims = claims
 
-    def get(self, property: str) -> list[Claim]:
+    def get(self, property: str | int) -> list[Claim]:
         if isinstance(property, int):
             property = 'P' + str(property)
 

--- a/wikibaseintegrator/models/snaks.py
+++ b/wikibaseintegrator/models/snaks.py
@@ -11,8 +11,14 @@ class Snaks(BaseModel):
     def __init__(self) -> None:
         self.snaks: dict[str, list[Snak]] = {}
 
-    def get(self, property: str) -> list[Snak]:
-        return self.snaks[property]
+    def get(self, property: str | int) -> list[Snak]:
+        if isinstance(property, int):
+            property = 'P' + str(property)
+
+        if property in self.snaks:
+            return self.snaks[property]
+
+        return []
 
     def add(self, snak: Snak) -> Snaks:
         property = snak.property_number


### PR DESCRIPTION
Hi @LeMyst 

I've noticed that when calling 'get' in Claims, if there is no claim for the given property, a KeyError will be raised.

I think it would be better to have the same behavior as in qualifiers.py, in which an empty list is returned if there is no qualifier for the given property. Feel free to disregard this though, if there is a reason for the current behavior that I am missing.
