### PR TITLE
Add Missing EDTF and LocalMedia Enums

### DIFF
--- a/wikibaseintegrator/wbi_enums.py
+++ b/wikibaseintegrator/wbi_enums.py
@@ -18,13 +18,14 @@ class ActionIfExists(Enum):
 
 class WikibaseDatatype(Enum):
     COMMONSMEDIA = 'commonsMedia'
-    EXTERNALID = 'external-id'
     EDTF = 'edtf'
+    EXTERNALID = 'external-id'
     FORM = 'wikibase-form'
     GEOSHAPE = 'geo-shape'
     GLOBECOORDINATE = 'globe-coordinate'
     ITEM = 'wikibase-item'
     LEXEME = 'wikibase-lexeme'
+    LOCALMEDIA = 'localMedia'
     MATH = 'math'
     MONOLINGUALTEXT = 'monolingualtext'
     MUSICALNOTATION = 'musical-notation'

--- a/wikibaseintegrator/wbi_enums.py
+++ b/wikibaseintegrator/wbi_enums.py
@@ -19,6 +19,7 @@ class ActionIfExists(Enum):
 class WikibaseDatatype(Enum):
     COMMONSMEDIA = 'commonsMedia'
     EXTERNALID = 'external-id'
+    EDTF = 'edtf'
     FORM = 'wikibase-form'
     GEOSHAPE = 'geo-shape'
     GLOBECOORDINATE = 'globe-coordinate'


### PR DESCRIPTION
This PR introduces two enum values, EDTF and LocalMedia, into the WikibaseDataType class. These additions aim to address the absence of these data types in our current implementation. However, this works for us, but I don't know if there's maybe still something missing