### PR TITLE
Disable test against 3.13

### DIFF
--- a/.github/workflows/python-pytest.yaml
+++ b/.github/workflows/python-pytest.yaml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13-dev' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ] # '3.13-dev' wait for new version of pypa/installer > 0.7.0
 
     steps:
       - uses: actions/checkout@v4.1.1


### PR DESCRIPTION
Wait for new release of pypa/installer greater than 0.7.0 who have MR https://github.com/pypa/installer/pull/201