### PR TITLE
Update the User-Agent policy URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ You can find more default settings in the file wbi_config.py
 
 If you interact with a Wikibase instance hosted by the Wikimedia Foundation (like Wikidata, Wikimedia Commons, etc.),
 it's highly advised to follow the User-Agent policy that you can find on the
-page [User-Agent policy](https://meta.wikimedia.org/wiki/User-Agent_policy)
+page [User-Agent policy](https://foundation.wikimedia.org/wiki/Policy:User-Agent_policy)
 of the Wikimedia Meta-Wiki.
 
 You can set a complementary User-Agent by modifying the variable `wbi_config['USER_AGENT']` in wbi_config.

--- a/wikibaseintegrator/wbi_config.py
+++ b/wikibaseintegrator/wbi_config.py
@@ -9,7 +9,7 @@ BACKOFF_MAX_TRIES: maximum number of times to retry failed request to wikidata e
 BACKOFF_MAX_VALUE: maximum number of seconds to wait before retrying. wait time will increase to this number
                    Default: 3600 (one hour)
 USER_AGENT:        Complementary user agent string used for http requests. Both to Wikibase api, query service and others.
-                   See: https://meta.wikimedia.org/wiki/User-Agent_policy
+                   See: https://foundation.wikimedia.org/wiki/Policy:User-Agent_policy
 """
 
 from typing import Dict, Union

--- a/wikibaseintegrator/wbi_helpers.py
+++ b/wikibaseintegrator/wbi_helpers.py
@@ -163,7 +163,7 @@ def mediawiki_api_call_helper(data: dict[str, Any], login: _Login | None = None,
     hostname = urlparse(mediawiki_api_url).hostname
     if hostname is not None and hostname.endswith(('wikidata.org', 'wikipedia.org', 'wikimedia.org')) and user_agent is None:
         log.warning('WARNING: Please set an user agent if you interact with a Wikibase instance from the Wikimedia Foundation.')
-        log.warning('More information in the README.md and https://meta.wikimedia.org/wiki/User-Agent_policy')
+        log.warning('More information in the README.md and https://foundation.wikimedia.org/wiki/Policy:User-Agent_policy')
 
     if not allow_anonymous:
         if login is None:
@@ -236,7 +236,7 @@ def execute_sparql_query(query: str, prefix: str | None = None, endpoint: str | 
     hostname = urlparse(sparql_endpoint_url).hostname
     if hostname is not None and hostname.endswith(('wikidata.org', 'wikipedia.org', 'wikimedia.org')) and user_agent is None:
         log.warning('WARNING: Please set an user agent if you interact with a Wikibase instance from the Wikimedia Foundation.')
-        log.warning('More information in the README.md and https://meta.wikimedia.org/wiki/User-Agent_policy')
+        log.warning('More information in the README.md and https://foundation.wikimedia.org/wiki/Policy:User-Agent_policy')
 
     if prefix:
         query = prefix + '\n' + query


### PR DESCRIPTION
On 29 March 2024 this page was moved from:
https://meta.wikimedia.org/wiki/User-Agent_policy
to
https://foundation.wikimedia.org/wiki/Policy:User-Agent_policy