### PR TITLE
Add EntitySchema data type

### DIFF
--- a/wikibaseintegrator/datatypes/__init__.py
+++ b/wikibaseintegrator/datatypes/__init__.py
@@ -1,5 +1,6 @@
 from .basedatatype import BaseDataType
 from .commonsmedia import CommonsMedia
+from .entityschema import EntitySchema
 from .externalid import ExternalID
 from .form import Form
 from .geoshape import GeoShape

--- a/wikibaseintegrator/datatypes/entityschema.py
+++ b/wikibaseintegrator/datatypes/entityschema.py
@@ -1,0 +1,42 @@
+import re
+from typing import Any, Optional
+
+from wikibaseintegrator.datatypes.basedatatype import BaseDataType
+
+
+class EntitySchema(BaseDataType):
+    """
+    Implements the Wikibase data type 'entity-schema'
+    """
+    DTYPE = 'entity-schema'
+
+    def __init__(self, value: Optional[str] = None, **kwargs: Any):
+        """
+        Constructor, calls the superclass BaseDataType
+
+        :param value: The EntitySchema ID to serve as the value
+        """
+
+        super().__init__(**kwargs)
+        self.set_value(value=value)
+
+    def set_value(self, value: Optional[str] = None):
+        assert isinstance(value, str) or value is None, f'Expected str, found {type(value)} ({value})'
+
+        if value:
+            if isinstance(value, str):
+                pattern = re.compile(r'^E[0-9]+$')
+                matches = pattern.match(value)
+
+                if not matches:
+                    raise ValueError(f"Invalid Entity Schema ({value}), format must be 'E[0-9]+'")
+
+                value = int(matches.group(1))
+
+            self.mainsnak.datavalue = {
+                'value': {
+                    'entity-type': 'entity-schema',
+                    'id': value
+                },
+                'type': 'wikibase-entityid'
+            }

--- a/wikibaseintegrator/datatypes/entityschema.py
+++ b/wikibaseintegrator/datatypes/entityschema.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from wikibaseintegrator.datatypes.basedatatype import BaseDataType
 
@@ -10,7 +10,7 @@ class EntitySchema(BaseDataType):
     """
     DTYPE = 'entity-schema'
 
-    def __init__(self, value: Optional[str] = None, **kwargs: Any):
+    def __init__(self, value: Optional[Union[str, int]] = None, **kwargs: Any):
         """
         Constructor, calls the superclass BaseDataType
 
@@ -20,23 +20,23 @@ class EntitySchema(BaseDataType):
         super().__init__(**kwargs)
         self.set_value(value=value)
 
-    def set_value(self, value: Optional[str] = None):
-        assert isinstance(value, str) or value is None, f'Expected str, found {type(value)} ({value})'
+    def set_value(self, value: Optional[Union[str, int]] = None):
+        assert isinstance(value, (str, int)) or value is None, f'Expected str or int, found {type(value)} ({value})'
 
         if value:
             if isinstance(value, str):
-                pattern = re.compile(r'^E[0-9]+$')
+                pattern = re.compile(r'^(?:[a-zA-Z]+:)?E?([0-9]+)$')
                 matches = pattern.match(value)
 
                 if not matches:
-                    raise ValueError(f"Invalid Entity Schema ({value}), format must be 'E[0-9]+'")
+                    raise ValueError(f"Invalid Entity Schema ID ({value}), format must be 'E[0-9]+'")
 
                 value = int(matches.group(1))
 
             self.mainsnak.datavalue = {
                 'value': {
                     'entity-type': 'entity-schema',
-                    'id': value
+                    'id': f'E{value}'
                 },
                 'type': 'wikibase-entityid'
             }

--- a/wikibaseintegrator/wbi_enums.py
+++ b/wikibaseintegrator/wbi_enums.py
@@ -21,6 +21,7 @@ class ActionIfExists(Enum):
 class WikibaseDatatype(Enum):
     COMMONSMEDIA = 'commonsMedia'
     EDTF = 'edtf'
+    ENTITYSCHEMA = 'entity-schema'
     EXTERNALID = 'external-id'
     FORM = 'wikibase-form'
     GEOSHAPE = 'geo-shape'


### PR DESCRIPTION
Hi @LeMyst,

I am seeing a new error when using basic functions such as item.get(). This is ultimately triggered by the new [EntitySchema data type](https://lists.wikimedia.org/hyperkitty/list/wikidata@lists.wikimedia.org/thread/LBEWI6IPD4H3S55KELZUOGFXPFRD5KYD/).

The error can be triggered by:
```
wbi.item.get('Q5')
```
and it happens for any entity that uses property [P12861](https://www.wikidata.org/wiki/Property:P12861). This is the error:
```
  File "/usr/local/lib/python3.11/site-packages/wikibaseintegrator/entities/item.py", line 127, in get
    return ItemEntity(api=self.api).from_json(json_data=json_data['entities'][entity_id])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/wikibaseintegrator/entities/item.py", line 143, in from_json
    super().from_json(json_data=json_data)
  File "/usr/local/lib/python3.11/site-packages/wikibaseintegrator/entities/baseentity.py", line 161, in from_json
    self.claims = Claims().from_json(json_data['claims'])
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/wikibaseintegrator/models/claims.py", line 128, in from_json
    data_type = [x for x in BaseDataType.subclasses if x.DTYPE == claim['mainsnak']['datatype']][0]
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

This PR adds this new data type so that these kind of errors are avoided. Maybe you prefer another approach if you don't plan to support this new data type. In any case, it would be helpful to fix the issue somehow. Thanks!