### PR TITLE
fix missing sitelinks in item.write()

### DIFF
--- a/wikibaseintegrator/entities/item.py
+++ b/wikibaseintegrator/entities/item.py
@@ -136,6 +136,7 @@ class ItemEntity(BaseEntity):
             'labels': self.labels.get_json(),
             'descriptions': self.descriptions.get_json(),
             'aliases': self.aliases.get_json(),
+            'sitelinks': self.sitelinks.get_json(),
             **super().get_json()
         }
 

--- a/wikibaseintegrator/models/sitelinks.py
+++ b/wikibaseintegrator/models/sitelinks.py
@@ -18,6 +18,16 @@ class Sitelinks(BaseModel):
         self.sitelinks[site] = sitelink
         return sitelink
 
+    def get_json(self) -> dict[str, dict]:
+        return {
+            sitelink:
+                {
+                    'site': self.sitelinks[sitelink].site,
+                    'title': self.sitelinks[sitelink].title,
+                    'badges': self.sitelinks[sitelink].badges
+                } for sitelink in self.sitelinks
+        }
+
     def from_json(self, json_data: dict[str, dict]) -> Sitelinks:
         for sitelink in json_data:
             self.set(site=json_data[sitelink]['site'], title=json_data[sitelink]['title'], badges=json_data[sitelink]['badges'])

--- a/wikibaseintegrator/wbi_helpers.py
+++ b/wikibaseintegrator/wbi_helpers.py
@@ -17,7 +17,7 @@ from requests import Session
 
 from wikibaseintegrator.wbi_backoff import wbi_backoff
 from wikibaseintegrator.wbi_config import config
-from wikibaseintegrator.wbi_exceptions import MaxRetriesReachedException, ModificationFailed, MWApiError, NonExistentEntityError, SearchError
+from wikibaseintegrator.wbi_exceptions import MaxRetriesReachedException, ModificationFailed, MWApiError, NonExistentEntityError, SearchError, SaveFailed
 
 if TYPE_CHECKING:
     from wikibaseintegrator.datatypes import BaseDataType
@@ -124,6 +124,12 @@ def mediawiki_api_call(method: str, mediawiki_api_url: str | None = None, sessio
             # duplicate error
             if 'code' in json_data['error'] and json_data['error']['code'] == 'modification-failed':  # pragma: no cover
                 raise ModificationFailed(json_data['error'])
+
+            # sitelink conflict
+            if ('code' in json_data['error'] and json_data['error']['code'] == 'failed-save' and
+                    any([message.get('name', '') == 'wikibase-validator-sitelink-conflict'
+                         for message in json_data['error'].get('messages', [])])):
+                raise SaveFailed(json_data['error'])
 
             # others case
             raise MWApiError(json_data['error'])

--- a/wikibaseintegrator/wbi_helpers.py
+++ b/wikibaseintegrator/wbi_helpers.py
@@ -17,7 +17,7 @@ from requests import Session
 
 from wikibaseintegrator.wbi_backoff import wbi_backoff
 from wikibaseintegrator.wbi_config import config
-from wikibaseintegrator.wbi_exceptions import MaxRetriesReachedException, ModificationFailed, MWApiError, NonExistentEntityError, SearchError, SaveFailed
+from wikibaseintegrator.wbi_exceptions import MaxRetriesReachedException, ModificationFailed, MWApiError, NonExistentEntityError, SaveFailed, SearchError
 
 if TYPE_CHECKING:
     from wikibaseintegrator.datatypes import BaseDataType


### PR DESCRIPTION
The latest version had a little bug, leading to sitelinks not being written, and in fact being lost in the write() process. Also shortly described in Issue #763 

This PR should fix it. 

I added an exception for the case that sitelinks are not unique, which could be more verbose - however seemed to somewhat fit into how exceptions are handled at the moment. Please let me know if anything is needed so we can merge!

Cheers

