### PR TITLE
Moving extra datatypes to be added to BaseDatatype subclasses.

### DIFF
--- a/test/test_all.py
+++ b/test/test_all.py
@@ -193,6 +193,31 @@ def test_mediainfo():
     assert mediainfo_item_by_id.id == 'M75908279'
 
 
+def test_entity_in_basedatatype():
+    assert len([x for x in BaseDataType.subclasses if x.DTYPE == 'commonsMedia']) == 1
+    assert len([x for x in BaseDataType.subclasses if x.DTYPE == 'entity-schema']) == 1
+    assert len([x for x in BaseDataType.subclasses if x.DTYPE == 'external-id']) == 1
+    assert len([x for x in BaseDataType.subclasses if x.DTYPE == 'wikibase-form']) == 1
+    assert len([x for x in BaseDataType.subclasses if x.DTYPE == 'geo-shape']) == 1
+    assert len([x for x in BaseDataType.subclasses if x.DTYPE == 'globe-coordinate']) == 1
+    assert len([x for x in BaseDataType.subclasses if x.DTYPE == 'wikibase-item']) == 1
+    assert len([x for x in BaseDataType.subclasses if x.DTYPE == 'wikibase-lexeme']) == 1
+    assert len([x for x in BaseDataType.subclasses if x.DTYPE == 'math']) == 1
+    assert len([x for x in BaseDataType.subclasses if x.DTYPE == 'monolingualtext']) == 1
+    assert len([x for x in BaseDataType.subclasses if x.DTYPE == 'musical-notation']) == 1
+    assert len([x for x in BaseDataType.subclasses if x.DTYPE == 'wikibase-property']) == 1
+    assert len([x for x in BaseDataType.subclasses if x.DTYPE == 'quantity']) == 1
+    assert len([x for x in BaseDataType.subclasses if x.DTYPE == 'wikibase-sense']) == 1
+    assert len([x for x in BaseDataType.subclasses if x.DTYPE == 'string']) == 1
+    assert len([x for x in BaseDataType.subclasses if x.DTYPE == 'tabular-data']) == 1
+    assert len([x for x in BaseDataType.subclasses if x.DTYPE == 'time']) == 1
+    assert len([x for x in BaseDataType.subclasses if x.DTYPE == 'url']) == 1
+
+    # Extra datatypes
+    assert len([x for x in BaseDataType.subclasses if x.DTYPE == 'edtf']) == 1
+    assert len([x for x in BaseDataType.subclasses if x.DTYPE == 'localMedia']) == 1
+
+
 def test_wikibaseintegrator():
     nwbi = WikibaseIntegrator(is_bot=False)
     assert nwbi.item.api.is_bot is False

--- a/wikibaseintegrator/datatypes/__init__.py
+++ b/wikibaseintegrator/datatypes/__init__.py
@@ -17,3 +17,8 @@ from .string import String
 from .tabulardata import TabularData
 from .time import Time
 from .url import URL
+
+# Extra datatypes
+# isort: off
+from .extra import EDTF
+from .extra import LocalMedia

--- a/wikibaseintegrator/datatypes/extra/edtf.py
+++ b/wikibaseintegrator/datatypes/extra/edtf.py
@@ -1,4 +1,4 @@
-from wikibaseintegrator.datatypes import String
+from wikibaseintegrator.datatypes.string import String
 
 
 class EDTF(String):

--- a/wikibaseintegrator/datatypes/extra/localmedia.py
+++ b/wikibaseintegrator/datatypes/extra/localmedia.py
@@ -1,4 +1,4 @@
-from wikibaseintegrator.datatypes import String
+from wikibaseintegrator.datatypes.string import String
 
 
 class LocalMedia(String):


### PR DESCRIPTION
This change adds the extra datatypes into the BaseDatatype subclasses list and solves the index out of range issue #798 

Couldnt find where to add the datatypes so they get added to the BaseDatatype subclasses, but adding them in the datatypes __init__ file added them. Please point in the right direction. 