### PR TITLE
Changed URL regex to allow brackets and angle brackets

### DIFF
--- a/wikibaseintegrator/datatypes/url.py
+++ b/wikibaseintegrator/datatypes/url.py
@@ -30,7 +30,8 @@ class URL(BaseDataType):
         assert isinstance(value, str) or value is None, f"Expected str, found {type(value)} ({value})"
 
         if value:
-            pattern = re.compile(r'^([a-z][a-z\d+.-]*):([^][<>\"\x00-\x20\x7F])+$')
+            # pattern = re.compile(r'^([a-z][a-z\d+.-]*):([^][<>\"\x00-\x20\x7F])+$')
+            pattern = re.compile(r'^([a-z][a-z\d+.-]*):([^\"\x00-\x20\x7F])+$')
             matches = pattern.match(value)
 
             if not matches:


### PR DESCRIPTION
Brackets and angle brackets are characters found in Digital Object Identifiers (and subsequently DOI-based URLs) from some publishers. I kept the basic structure of the original regex pattern (commented out) to retain the rest of the logic. Another approach here might be to use (or add) the checkurl action from a given Wikimedia API to validate that a URL can be included in an eventual write operation.