### PR TITLE
Update OAuth2 test to expect MissingTokenError

### DIFF
--- a/test/test_wbi_login.py
+++ b/test/test_wbi_login.py
@@ -3,6 +3,7 @@ import sys
 import unittest
 
 import pytest
+from oauthlib.oauth2 import MissingTokenError
 
 from wikibaseintegrator import wbi_login
 from wikibaseintegrator.wbi_helpers import mediawiki_api_call_helper
@@ -61,7 +62,7 @@ def test_oauth1_access():
 
 
 def test_oauth2():
-    with unittest.TestCase().assertRaises(LoginError):
+    with unittest.TestCase().assertRaises(MissingTokenError):
         login = wbi_login.OAuth2(consumer_token='wrong', consumer_secret='wrong')
         login.generate_edit_credentials()
 

--- a/wikibaseintegrator/datatypes/string.py
+++ b/wikibaseintegrator/datatypes/string.py
@@ -24,7 +24,7 @@ class String(BaseDataType):
         assert isinstance(value, str) or value is None, f"Expected str, found {type(value)} ({value})"
 
         if value and ('\n' in value or '\r' in value):
-            raise ValueError("String value must not contain new ine character")
+            raise ValueError("String value must not contain new line character")
 
         if value:
             self.mainsnak.datavalue = {


### PR DESCRIPTION
Changed the OAuth2 login test to assert that MissingTokenError is raised instead of LoginError, reflecting the expected exception from oauthlib when credentials are invalid.