### PR TITLE
Add useragent in login queries

### DIFF
--- a/test/test_wbi_login.py
+++ b/test/test_wbi_login.py
@@ -3,6 +3,7 @@ import sys
 import unittest
 
 import pytest
+from oauthlib.oauth2 import MissingTokenError
 
 from wikibaseintegrator import wbi_login
 from wikibaseintegrator.wbi_helpers import mediawiki_api_call_helper
@@ -61,7 +62,7 @@ def test_oauth1_access():
 
 
 def test_oauth2():
-    with unittest.TestCase().assertRaises(LoginError):
+    with pytest.raises((MissingTokenError, LoginError)):
         login = wbi_login.OAuth2(consumer_token='wrong', consumer_secret='wrong')
         login.generate_edit_credentials()
 

--- a/wikibaseintegrator/datatypes/string.py
+++ b/wikibaseintegrator/datatypes/string.py
@@ -24,7 +24,7 @@ class String(BaseDataType):
         assert isinstance(value, str) or value is None, f"Expected str, found {type(value)} ({value})"
 
         if value and ('\n' in value or '\r' in value):
-            raise ValueError("String value must not contain new ine character")
+            raise ValueError("String value must not contain new line character")
 
         if value:
             self.mainsnak.datavalue = {

--- a/wikibaseintegrator/wbi_login.py
+++ b/wikibaseintegrator/wbi_login.py
@@ -211,6 +211,7 @@ class Login(_Login):
         """
 
         mediawiki_api_url = str(mediawiki_api_url or config['MEDIAWIKI_API_URL'])
+        user_agent = user_agent or (str(config['USER_AGENT']) if config['USER_AGENT'] is not None else None)
         session = Session()
 
         params_login = {
@@ -220,8 +221,12 @@ class Login(_Login):
             'format': 'json'
         }
 
+        headers = {
+            'User-Agent': get_user_agent(user_agent)
+        }
+
         # get login token
-        login_token = session.post(mediawiki_api_url, data=params_login).json()['query']['tokens']['logintoken']
+        login_token = session.post(mediawiki_api_url, data=params_login, headers=headers).json()['query']['tokens']['logintoken']
 
         params = {
             'action': 'login',
@@ -231,7 +236,7 @@ class Login(_Login):
             'format': 'json'
         }
 
-        login_result = session.post(mediawiki_api_url, data=params).json()
+        login_result = session.post(mediawiki_api_url, data=params, headers=headers).json()
 
         if 'login' in login_result and login_result['login']['result'] == 'Success':
             log.info("Successfully logged in as %s", login_result['login']['lgusername'])
@@ -260,6 +265,7 @@ class Clientlogin(_Login):
         """
 
         mediawiki_api_url = str(mediawiki_api_url or config['MEDIAWIKI_API_URL'])
+        user_agent = user_agent or (str(config['USER_AGENT']) if config['USER_AGENT'] is not None else None)
         session = Session()
 
         params_login = {
@@ -269,8 +275,12 @@ class Clientlogin(_Login):
             'format': 'json'
         }
 
+        headers = {
+            'User-Agent': get_user_agent(user_agent)
+        }
+
         # get login token
-        login_token = session.post(mediawiki_api_url, data=params_login).json()['query']['tokens']['logintoken']
+        login_token = session.post(mediawiki_api_url, data=params_login, headers=headers).json()['query']['tokens']['logintoken']
 
         params = {
             'action': 'clientlogin',
@@ -281,7 +291,7 @@ class Clientlogin(_Login):
             'format': 'json'
         }
 
-        login_result = session.post(mediawiki_api_url, data=params).json()
+        login_result = session.post(mediawiki_api_url, data=params, headers=headers).json()
 
         log.debug(login_result)
 


### PR DESCRIPTION
This pull request improves login handling and error reporting in the Wikibase Integrator codebase. The main changes include ensuring the correct `User-Agent` header is sent during login requests, improving error handling for OAuth2 authentication, and fixing a typo in an exception message.

**Login flow improvements:**

* Both the `Login` and `ClientLogin` classes in `wikibaseintegrator/wbi_login.py` now consistently include a `User-Agent` header in their API requests, using the configured or provided user agent string. This helps with request identification and compliance with API requirements. [[1]](diffhunk://#diff-f2e514f52b4a1fa357da94763ca9976cf60c744b6424aa6fd56ce915c2ea91b7R214) [[2]](diffhunk://#diff-f2e514f52b4a1fa357da94763ca9976cf60c744b6424aa6fd56ce915c2ea91b7R224-R229) [[3]](diffhunk://#diff-f2e514f52b4a1fa357da94763ca9976cf60c744b6424aa6fd56ce915c2ea91b7L234-R239) [[4]](diffhunk://#diff-f2e514f52b4a1fa357da94763ca9976cf60c744b6424aa6fd56ce915c2ea91b7R268) [[5]](diffhunk://#diff-f2e514f52b4a1fa357da94763ca9976cf60c744b6424aa6fd56ce915c2ea91b7R278-R283) [[6]](diffhunk://#diff-f2e514f52b4a1fa357da94763ca9976cf60c744b6424aa6fd56ce915c2ea91b7L284-R294)

**Error handling and testing:**

* The OAuth2 login test in `test/test_wbi_login.py` now expects both `MissingTokenError` and `LoginError`, making the test more robust to different failure modes.
* The `MissingTokenError` import from `oauthlib.oauth2` is added to `test/test_wbi_login.py` to support the expanded error handling in tests.

**Minor fixes:**

* A typo in the exception message in `wikibaseintegrator/datatypes/string.py` is corrected from "new ine character" to "new line character".