### PR TITLE
enforce exact max results in search_entities

### DIFF
--- a/wikibaseintegrator/wbi_helpers.py
+++ b/wikibaseintegrator/wbi_helpers.py
@@ -439,7 +439,7 @@ def search_entities(search_string: str, language: str | None = None, strict_lang
 
     language = str(language or config['DEFAULT_LANGUAGE'])
 
-    params = {
+    params: dict[str, str | int] = {
         'action': 'wbsearchentities',
         'search': search_string,
         'language': language,

--- a/wikibaseintegrator/wbi_helpers.py
+++ b/wikibaseintegrator/wbi_helpers.py
@@ -444,7 +444,6 @@ def search_entities(search_string: str, language: str | None = None, strict_lang
         'search': search_string,
         'language': language,
         'type': search_type,
-        'limit': 50,
         'format': 'json'
     }
 
@@ -455,7 +454,8 @@ def search_entities(search_string: str, language: str | None = None, strict_lang
     results = []
 
     while True:
-        params.update({'continue': cont_count})
+        max_page_results = min(50, max_results - cont_count)
+        params.update({'continue': cont_count, 'limit': max_page_results})
 
         search_results = mediawiki_api_call_helper(data=params, allow_anonymous=allow_anonymous, **kwargs)
 


### PR DESCRIPTION
Now "max" means max.

This prevents overwhelming downstream systems, especially if the developer loads these into a database without realizing. #askingForAFriend ;)