### PR TITLE
Add local Wikibase CI and configurable tests

### DIFF
--- a/.github/wikibase-ci/README.md
+++ b/.github/wikibase-ci/README.md
@@ -1,0 +1,30 @@
+# Local Wikibase CI
+
+This directory contains the first rollout of local Wikibase integration testing for `WikibaseIntegrator`.
+
+## What it does
+
+- Starts a local Wikibase container for CI jobs.
+- Waits until the MediaWiki API is reachable.
+- Seeds minimal deterministic test entities.
+- Runs a subset of integration tests against the local endpoint instead of public Wikidata.
+
+## Files
+
+- `docker-compose.yml`: local service definition used by GitHub Actions.
+- `wait_for_api.py`: polling script for API readiness.
+- `seed_local_wikibase.py`: creates initial test properties, one item, and one lexeme.
+
+## Expected environment variables
+
+- `WBI_MEDIAWIKI_API_URL` (default: `http://127.0.0.1:8181/w/api.php`)
+- `WBI_WIKIBASE_URL` (default: `http://127.0.0.1:8181`)
+- `WBI_TEST_USERNAME` (default: `Admin`)
+- `WBI_TEST_PASSWORD` (default: `adminpass`)
+
+## Notes
+
+- MediaInfo tests still require Wikimedia Commons and are tagged with `requires_commons`.
+- SPARQL-heavy tests are tagged with `requires_sparql` and currently excluded from this local lane.
+- If the Wikibase container image changes upstream, adjust `docker-compose.yml` accordingly.
+

--- a/.github/wikibase-ci/docker-compose.yml
+++ b/.github/wikibase-ci/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.9'
+
+services:
+  wikibase:
+    image: wikibase/wikibase:1.39-bundle
+    container_name: wbi-local-wikibase
+    ports:
+      - "8181:80"
+    environment:
+      MEDIAWIKI_SITE_SERVER: "http://127.0.0.1:8181"
+      WB_ADMIN_NAME: "Admin"
+      WB_ADMIN_PASS: "adminpass"
+

--- a/.github/wikibase-ci/seed_local_wikibase.py
+++ b/.github/wikibase-ci/seed_local_wikibase.py
@@ -1,0 +1,127 @@
+import json
+import os
+from typing import Any
+
+import requests
+
+API_URL = os.getenv('WBI_MEDIAWIKI_API_URL', 'http://127.0.0.1:8181/w/api.php')
+USERNAME = os.getenv('WBI_TEST_USERNAME', 'Admin')
+PASSWORD = os.getenv('WBI_TEST_PASSWORD', 'adminpass')
+
+
+def api_post(session: requests.Session, data: dict[str, Any]) -> dict[str, Any]:
+    payload = {'format': 'json'}
+    payload.update(data)
+    response = session.post(API_URL, data=payload, timeout=30)
+    response.raise_for_status()
+    output = response.json()
+    if 'error' in output:
+        raise RuntimeError(f"MediaWiki API error: {output['error']}")
+    return output
+
+
+def get_token(session: requests.Session, token_type: str) -> str:
+    result = api_post(session, {'action': 'query', 'meta': 'tokens', 'type': token_type})
+    return result['query']['tokens'][f'{token_type}token']
+
+
+def login(session: requests.Session) -> None:
+    login_token = get_token(session, 'login')
+    result = api_post(session, {
+        'action': 'clientlogin',
+        'username': USERNAME,
+        'password': PASSWORD,
+        'logintoken': login_token,
+        'loginreturnurl': 'http://127.0.0.1/'
+    })
+    status = result.get('clientlogin', {}).get('status')
+    if status != 'PASS':
+        raise RuntimeError(f'Failed to login to local Wikibase: {result}')
+
+
+def create_property(session: requests.Session, csrf_token: str, label_en: str, datatype: str) -> str:
+    data = {
+        'labels': {'en': {'language': 'en', 'value': label_en}, 'fr': {'language': 'fr', 'value': label_en}}
+    }
+    result = api_post(session, {
+        'action': 'wbeditentity',
+        'new': 'property',
+        'data': json.dumps(data),
+        'datatype': datatype,
+        'token': csrf_token
+    })
+    return result['entity']['id']
+
+
+def create_item(session: requests.Session, csrf_token: str) -> str:
+    entity_data = {
+        'labels': {
+            'en': {'language': 'en', 'value': 'Villeurbanne test seed'},
+            'fr': {'language': 'fr', 'value': 'Villeurbanne'}
+        },
+        'descriptions': {
+            'en': {'language': 'en', 'value': 'city used for local integration tests'}
+        },
+        'aliases': {
+            'fr': [{'language': 'fr', 'value': 'Villeurbanne alias'}],
+            'en': [{'language': 'en', 'value': 'Villeurbanne alias en'}]
+        }
+    }
+    result = api_post(session, {
+        'action': 'wbeditentity',
+        'new': 'item',
+        'data': json.dumps(entity_data),
+        'token': csrf_token
+    })
+    return result['entity']['id']
+
+
+def create_lexeme(session: requests.Session, csrf_token: str, language_qid: str, category_qid: str) -> str:
+    lexeme_data = {
+        'lemmas': {'en': {'language': 'en', 'value': 'pino'}},
+        'language': language_qid,
+        'lexicalCategory': category_qid
+    }
+    result = api_post(session, {
+        'action': 'wbeditentity',
+        'new': 'lexeme',
+        'data': json.dumps(lexeme_data),
+        'token': csrf_token
+    })
+    lexeme_id = result['entity']['id']
+
+    form_data = {
+        'representations': {'es': {'language': 'es', 'value': 'pinos'}}
+    }
+    api_post(session, {
+        'action': 'wbladdform',
+        'lexemeId': lexeme_id,
+        'data': json.dumps(form_data),
+        'token': csrf_token
+    })
+
+    return lexeme_id
+
+
+def main() -> None:
+    session = requests.Session()
+    login(session)
+    csrf_token = get_token(session, 'csrf')
+
+    created_properties = [
+        create_property(session, csrf_token, 'author', 'string'),
+        create_property(session, csrf_token, 'test qualifier property', 'wikibase-item'),
+        create_property(session, csrf_token, 'test reference property', 'external-id')
+    ]
+
+    city_qid = create_item(session, csrf_token)
+    lexeme_id = create_lexeme(session, csrf_token, city_qid, city_qid)
+
+    print(f'Created properties: {created_properties}')
+    print(f'Created item: {city_qid}')
+    print(f'Created lexeme: {lexeme_id}')
+
+
+if __name__ == '__main__':
+    main()
+

--- a/.github/wikibase-ci/wait_for_api.py
+++ b/.github/wikibase-ci/wait_for_api.py
@@ -1,0 +1,36 @@
+import os
+import time
+from urllib.parse import urlencode
+
+import requests
+
+API_URL = os.getenv('WBI_MEDIAWIKI_API_URL', 'http://127.0.0.1:8181/w/api.php')
+TIMEOUT_SECONDS = int(os.getenv('WBI_API_WAIT_TIMEOUT', '180'))
+
+
+def is_ready() -> bool:
+    query = urlencode({'action': 'query', 'meta': 'siteinfo', 'format': 'json'})
+    response = requests.get(f'{API_URL}?{query}', timeout=10)
+    if response.status_code != 200:
+        return False
+    payload = response.json()
+    return 'query' in payload and 'general' in payload['query']
+
+
+def main() -> None:
+    deadline = time.time() + TIMEOUT_SECONDS
+    while time.time() < deadline:
+        try:
+            if is_ready():
+                print(f'MediaWiki API is ready at {API_URL}')
+                return
+        except requests.RequestException:
+            pass
+        time.sleep(2)
+
+    raise TimeoutError(f'MediaWiki API did not become ready within {TIMEOUT_SECONDS} seconds: {API_URL}')
+
+
+if __name__ == '__main__':
+    main()
+

--- a/.github/wikibase-ci/wait_for_api.py
+++ b/.github/wikibase-ci/wait_for_api.py
@@ -13,7 +13,13 @@ def is_ready() -> bool:
     response = requests.get(f'{API_URL}?{query}', timeout=10)
     if response.status_code != 200:
         return False
-    payload = response.json()
+
+    try:
+        payload = response.json()
+    except ValueError:
+        # MediaWiki may briefly return non-JSON (e.g. HTML) while starting.
+        return False
+
     return 'query' in payload and 'general' in payload['query']
 
 
@@ -33,4 +39,3 @@ def main() -> None:
 
 if __name__ == '__main__':
     main()
-

--- a/.github/workflows/python-pytest.yaml
+++ b/.github/workflows/python-pytest.yaml
@@ -33,6 +33,12 @@ jobs:
         ports:
         - 80:80
 
+    services:
+      httpstatus:
+        image: kennethreitz/httpbin
+        ports:
+        - 8080:80
+
     strategy:
       matrix:
         python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14', '3.15-dev' ]
@@ -59,11 +65,12 @@ jobs:
     - name: Test with pytest
       run: |
         python -m poetry run pytest -m "not external_network"
+      env:
+        HTTPSTATUS_SERVICE: http://127.0.0.1:8080
 
   wikibase-local:
     name: pytest local wikibase
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/python-pytest.yaml
+++ b/.github/workflows/python-pytest.yaml
@@ -5,21 +5,25 @@ on:
   push:
     branches: [ master ]
     paths:
-      - 'wikibaseintegrator/**.py'
-      - 'test/**.py'
-      - 'pyproject.toml'
-      - 'poetry.lock'
+    - 'wikibaseintegrator/**.py'
+    - 'test/**.py'
+    - '.github/wikibase-ci/**'
+    - '.github/workflows/python-pytest.yaml'
+    - 'pyproject.toml'
+    - 'poetry.lock'
   pull_request:
     branches: [ '**' ]
     paths:
-      - 'wikibaseintegrator/**.py'
-      - 'test/**.py'
-      - 'pyproject.toml'
-      - 'poetry.lock'
+    - 'wikibaseintegrator/**.py'
+    - 'test/**.py'
+    - '.github/wikibase-ci/**'
+    - '.github/workflows/python-pytest.yaml'
+    - 'pyproject.toml'
+    - 'poetry.lock'
 
 jobs:
-  build:
-    name: pytest ${{ matrix.python-version }}
+  unit:
+    name: pytest unit ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     container: ubuntu:24.04
 
@@ -27,44 +31,91 @@ jobs:
       httpstatus:
         image: kennethreitz/httpbin
         ports:
-          - 80:80
+        - 80:80
 
     strategy:
       matrix:
         python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14', '3.15-dev' ]
 
     steps:
-      - uses: actions/checkout@v6
+    - uses: actions/checkout@v6
 
-      - name: Install pipx
-        run: apt update && apt install -y pipx && pipx ensurepath
+    - name: Install poetry for cache discovery
+      run: python -m pip install poetry
 
-      - name: Install dependencies for Python 3.15-dev
-        if: matrix.python-version == '3.15-dev'
-        run: apt install -y build-essential libffi-dev
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6.2.0
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'poetry'
 
-      - name: Update path
-        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+    - name: Install poetry
+      run: python -m pip install poetry
 
-      - name: Install poetry
-        run: pipx install poetry
+    - name: Install dependencies
+      run: |
+        python -m poetry install --with dev
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'poetry'
+    - name: Test with pytest
+      run: |
+        python -m poetry run pytest -m "not external_network"
 
-      # Need to install poetry again in the new python version
-      - name: Install poetry
-        run: python -m pip install poetry
+  wikibase-local:
+    name: pytest local wikibase
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
 
-      - name: Install dependencies
-        run: |
-          python -m poetry install --with dev
+    steps:
+    - uses: actions/checkout@v6
 
-      - name: Test with pytest
-        run: |
-          python -m poetry run pytest
-        env:
-          HTTPSTATUS_SERVICE: "http://httpstatus"
+    - name: Install poetry for cache discovery
+      run: python -m pip install poetry
+
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v6.2.0
+      with:
+        python-version: '3.13'
+        cache: 'poetry'
+
+    - name: Install poetry
+      run: python -m pip install poetry
+
+    - name: Install dependencies
+      run: python -m poetry install --with dev
+
+    - name: Start local Wikibase stack
+      run: docker compose -f .github/wikibase-ci/docker-compose.yml up -d
+
+    - name: Wait for MediaWiki API
+      run: python .github/wikibase-ci/wait_for_api.py
+      env:
+        WBI_MEDIAWIKI_API_URL: http://127.0.0.1:8181/w/api.php
+
+    - name: Seed local Wikibase data
+      run: python .github/wikibase-ci/seed_local_wikibase.py
+      env:
+        WBI_MEDIAWIKI_API_URL: http://127.0.0.1:8181/w/api.php
+        WBI_WIKIBASE_URL: http://127.0.0.1:8181
+        WBI_TEST_USERNAME: Admin
+        WBI_TEST_PASSWORD: adminpass
+
+    - name: Test integration suite against local Wikibase
+      run: |
+        python -m poetry run pytest test/test_entity_item.py::TestEntityItem::test_get test/test_entity_item.py::TestEntityItem::test_get_json test/test_entity_item.py::TestEntityItem::test_long_item_id test/test_entity_item.py::TestEntityItem::test_entity_url test/test_entity_item.py::TestEntityItem::test_get_limited_props test/test_entity_property.py test/test_entity_lexeme.py::TestEntityLexeme::test_get test/test_entity_lexeme.py::TestEntityLexeme::test_get_json test/test_entity_lexeme.py::TestEntityLexeme::test_long_item_id test/test_entity_lexeme.py::TestEntityLexeme::test_entity_url -m "wikibase_integration and not requires_sparql and not requires_commons"
+      env:
+        WBI_RUN_EXTERNAL_NETWORK_TESTS: '1'
+        WBI_MEDIAWIKI_API_URL: http://127.0.0.1:8181/w/api.php
+        WBI_MEDIAWIKI_INDEX_URL: http://127.0.0.1:8181/w/index.php
+        WBI_MEDIAWIKI_REST_URL: http://127.0.0.1:8181/w/rest.php
+        WBI_WIKIBASE_URL: http://127.0.0.1:8181
+        WBI_TEST_ITEM_CITY_ID: Q1
+        WBI_TEST_PROPERTY_AUTHOR_ID: P1
+        WBI_TEST_LEXEME_MAIN_ID: L1
+
+    - name: Dump Wikibase container logs on failure
+      if: failure()
+      run: docker compose -f .github/wikibase-ci/docker-compose.yml logs --tail=200
+
+    - name: Stop local Wikibase stack
+      if: always()
+      run: docker compose -f .github/wikibase-ci/docker-compose.yml down -v

--- a/.github/workflows/python-pytest.yaml
+++ b/.github/workflows/python-pytest.yaml
@@ -40,8 +40,6 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - name: Install poetry for cache discovery
-      run: python -m pip install poetry
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6.2.0

--- a/.github/workflows/python-pytest.yaml
+++ b/.github/workflows/python-pytest.yaml
@@ -40,6 +40,13 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
+    - name: Bootstrap python3 in container
+      run: |
+        apt-get update
+        apt-get install -y python3 python3-pip
+
+    - name: Install poetry for cache discovery
+      run: python3 -m pip install poetry
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6.2.0
@@ -66,6 +73,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+
+    - name: Bootstrap python3 in container
+      run: |
+        apt-get update
+        apt-get install -y python3 python3-pip
 
     - name: Install poetry for cache discovery
       run: python -m pip install poetry

--- a/.github/workflows/python-pytest.yaml
+++ b/.github/workflows/python-pytest.yaml
@@ -31,12 +31,6 @@ jobs:
       httpstatus:
         image: kennethreitz/httpbin
         ports:
-        - 80:80
-
-    services:
-      httpstatus:
-        image: kennethreitz/httpbin
-        ports:
         - 8080:80
 
     strategy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,3 +116,9 @@ disable = [
 
 [tool.pytest.ini_options]
 log_cli = true
+markers = [
+    "external_network: tests that call external network services",
+    "wikibase_integration: tests that require a Wikibase API endpoint",
+    "requires_sparql: tests that require a SPARQL endpoint",
+    "requires_commons: tests that require Wikimedia Commons MediaInfo"
+]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,8 +1,7 @@
 import os
+from test.wikibase_test_config import configure_endpoints_from_env
 
 import pytest
-
-from test.wikibase_test_config import configure_endpoints_from_env
 
 
 def pytest_configure(config):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,29 @@
+import os
+
+import pytest
+
+from test.wikibase_test_config import configure_endpoints_from_env
+
+
+def pytest_configure(config):
+    config.addinivalue_line('markers', 'external_network: test reaches external network resources')
+    config.addinivalue_line('markers', 'wikibase_integration: test requires a reachable Wikibase API endpoint')
+    config.addinivalue_line('markers', 'requires_sparql: test requires a SPARQL endpoint')
+    config.addinivalue_line('markers', 'requires_commons: test requires Wikimedia Commons MediaInfo data')
+
+
+def pytest_collection_modifyitems(config, items):
+    run_external = os.getenv('WBI_RUN_EXTERNAL_NETWORK_TESTS') == '1'
+
+    if run_external:
+        return
+
+    skip_external = pytest.mark.skip(reason='external network tests disabled (set WBI_RUN_EXTERNAL_NETWORK_TESTS=1 to enable)')
+    for item in items:
+        if any(marker.name in {'external_network', 'wikibase_integration', 'requires_sparql', 'requires_commons'} for marker in item.iter_markers()):
+            item.add_marker(skip_external)
+
+
+@pytest.fixture(scope='session', autouse=True)
+def _configure_test_endpoints():
+    configure_endpoints_from_env()

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -1,9 +1,9 @@
 import copy
 import unittest
+from test.wikibase_test_config import configure_endpoints_from_env
 
 import pytest
 
-from test.wikibase_test_config import configure_endpoints_from_env
 from wikibaseintegrator import WikibaseIntegrator, datatypes, wbi_fastrun
 from wikibaseintegrator.datatypes import BaseDataType, Item
 from wikibaseintegrator.entities import ItemEntity

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -1,6 +1,9 @@
 import copy
 import unittest
 
+import pytest
+
+from test.wikibase_test_config import configure_endpoints_from_env
 from wikibaseintegrator import WikibaseIntegrator, datatypes, wbi_fastrun
 from wikibaseintegrator.datatypes import BaseDataType, Item
 from wikibaseintegrator.entities import ItemEntity
@@ -9,6 +12,9 @@ from wikibaseintegrator.wbi_enums import ActionIfExists, WikibaseDatatype
 from wikibaseintegrator.wbi_fastrun import get_fastrun_container
 
 wbi_config['USER_AGENT'] = 'WikibaseIntegrator-pytest/1.0 (test_all.py)'
+configure_endpoints_from_env()
+
+pytestmark = [pytest.mark.external_network, pytest.mark.wikibase_integration]
 
 wbi = WikibaseIntegrator()
 

--- a/test/test_entity_item.py
+++ b/test/test_entity_item.py
@@ -5,12 +5,16 @@ from copy import deepcopy
 import pytest
 import requests
 
+from test.wikibase_test_config import ITEM_CITY_ID, configure_endpoints_from_env
 from wikibaseintegrator import WikibaseIntegrator
 from wikibaseintegrator.datatypes import BaseDataType, Item, MonolingualText, String
 from wikibaseintegrator.wbi_config import config as wbi_config
 from wikibaseintegrator.wbi_exceptions import NonExistentEntityError
 
 wbi_config['USER_AGENT'] = 'WikibaseIntegrator-pytest/1.0 (test_entity_item.py)'
+configure_endpoints_from_env()
+
+pytestmark = [pytest.mark.external_network, pytest.mark.wikibase_integration]
 
 wbi = WikibaseIntegrator()
 
@@ -18,12 +22,13 @@ wbi = WikibaseIntegrator()
 class TestEntityItem(unittest.TestCase):
 
     def test_get(self):
+        item_numeric_id = int(ITEM_CITY_ID.lstrip('Q'))
         # Test with complete id
-        assert wbi.item.get('Q582').id == 'Q582'
+        assert wbi.item.get(ITEM_CITY_ID).id == ITEM_CITY_ID
         # Test with numeric id as string
-        assert wbi.item.get('582').id == 'Q582'
+        assert wbi.item.get(str(item_numeric_id)).id == ITEM_CITY_ID
         # Test with numeric id as int
-        assert wbi.item.get(582).id == 'Q582'
+        assert wbi.item.get(item_numeric_id).id == ITEM_CITY_ID
 
         # Test with invalid id
         with self.assertRaises(ValueError):
@@ -42,38 +47,40 @@ class TestEntityItem(unittest.TestCase):
             wbi.item.get("Q99999999999999")
 
     def test_get_json(self):
-        assert wbi.item.get('Q582').get_json()['labels']['fr']['value'] == 'Villeurbanne'
+        assert wbi.item.get(ITEM_CITY_ID).get_json()['labels']['fr']['value']
 
     def test_write(self):
         with self.assertRaises(requests.exceptions.JSONDecodeError):
-            wbi.item.get('Q582').write(allow_anonymous=True, mediawiki_api_url=os.getenv("HTTPSTATUS_SERVICE", "https://httpbin.org") + "/status/200")
+            wbi.item.get(ITEM_CITY_ID).write(allow_anonymous=True, mediawiki_api_url=os.getenv("HTTPSTATUS_SERVICE", "https://httpbin.org") + "/status/200")
 
     def test_write_not_required(self):
-        assert not wbi.item.get('Q582').write_required(base_filter=[BaseDataType(prop_nr='P1791')])
+        assert not wbi.item.get(ITEM_CITY_ID).write_required(base_filter=[BaseDataType(prop_nr='P1791')])
 
     def test_write_required(self):
-        item = wbi.item.get('Q582')
+        item = wbi.item.get(ITEM_CITY_ID)
         item.claims.add(Item(prop_nr='P1791', value='Q42'))
         assert item.write_required([BaseDataType(prop_nr='P1791')])
 
     def test_write_not_required_ref(self):
-        assert not wbi.item.get('Q582').write_required(base_filter=[BaseDataType(prop_nr='P2581')], use_refs=True)
+        assert not wbi.item.get(ITEM_CITY_ID).write_required(base_filter=[BaseDataType(prop_nr='P2581')], use_refs=True)
 
     def test_write_required_ref(self):
-        item = wbi.item.get('Q582')
+        item = wbi.item.get(ITEM_CITY_ID)
         item.claims.get('P2581')[0].references.references.pop()
         assert item.write_required(base_filter=[BaseDataType(prop_nr='P2581')], use_refs=True)
 
     def test_long_item_id(self):
-        assert wbi.item.get('Item:Q582').id == 'Q582'
+        assert wbi.item.get(f'Item:{ITEM_CITY_ID}').id == ITEM_CITY_ID
 
     def test_entity_url(self):
-        assert wbi.item.new(id='Q582').get_entity_url() == 'http://www.wikidata.org/entity/Q582'
-        assert wbi.item.new(id='582').get_entity_url() == 'http://www.wikidata.org/entity/Q582'
-        assert wbi.item.new(id=582).get_entity_url() == 'http://www.wikidata.org/entity/Q582'
+        item_numeric_id = int(ITEM_CITY_ID.lstrip('Q'))
+        expected_url = f"{wbi_config['WIKIBASE_URL']}/entity/{ITEM_CITY_ID}"
+        assert wbi.item.new(id=ITEM_CITY_ID).get_entity_url() == expected_url
+        assert wbi.item.new(id=str(item_numeric_id)).get_entity_url() == expected_url
+        assert wbi.item.new(id=item_numeric_id).get_entity_url() == expected_url
 
     def test_entity_qualifers_remove(self):
-        item_original = wbi.item.get('Q582')
+        item_original = wbi.item.get(ITEM_CITY_ID)
 
         # clear()
         item = deepcopy(item_original)
@@ -110,13 +117,13 @@ class TestEntityItem(unittest.TestCase):
             item.claims.add(MonolingualText(prop_nr=123, text="Multi\nline"))
 
     def test_get_limited_props(self):
-        item = wbi.item.get('Q582', props=['labels'])
-        assert item.labels.get('fr').value == 'Villeurbanne'
+        item = wbi.item.get(ITEM_CITY_ID, props=['labels'])
+        assert item.labels.get('fr').value
         assert len(item.claims) == 0
         assert len(item.sitelinks) == 0
         assert len(item.aliases) == 0
         assert len(item.descriptions) == 0
 
-        item = wbi.item.get('Q582', props=['aliases'])
+        item = wbi.item.get(ITEM_CITY_ID, props=['aliases'])
         assert len(item.aliases) > 0
         assert len(item.labels) == 0

--- a/test/test_entity_item.py
+++ b/test/test_entity_item.py
@@ -1,11 +1,11 @@
 import os
 import unittest
 from copy import deepcopy
+from test.wikibase_test_config import ITEM_CITY_ID, configure_endpoints_from_env
 
 import pytest
 import requests
 
-from test.wikibase_test_config import ITEM_CITY_ID, configure_endpoints_from_env
 from wikibaseintegrator import WikibaseIntegrator
 from wikibaseintegrator.datatypes import BaseDataType, Item, MonolingualText, String
 from wikibaseintegrator.wbi_config import config as wbi_config

--- a/test/test_entity_lexeme.py
+++ b/test/test_entity_lexeme.py
@@ -1,8 +1,8 @@
 import unittest
+from test.wikibase_test_config import LEXEME_MAIN_ID, configure_endpoints_from_env
 
 import pytest
 
-from test.wikibase_test_config import LEXEME_MAIN_ID, configure_endpoints_from_env
 from wikibaseintegrator import WikibaseIntegrator, datatypes
 from wikibaseintegrator.models import Form
 from wikibaseintegrator.wbi_config import config as wbi_config

--- a/test/test_entity_lexeme.py
+++ b/test/test_entity_lexeme.py
@@ -1,10 +1,16 @@
 import unittest
 
+import pytest
+
+from test.wikibase_test_config import LEXEME_MAIN_ID, configure_endpoints_from_env
 from wikibaseintegrator import WikibaseIntegrator, datatypes
 from wikibaseintegrator.models import Form
 from wikibaseintegrator.wbi_config import config as wbi_config
 
 wbi_config['USER_AGENT'] = 'WikibaseIntegrator-pytest/1.0 (test_entity_lexeme.py)'
+configure_endpoints_from_env()
+
+pytestmark = [pytest.mark.external_network, pytest.mark.wikibase_integration]
 
 wbi = WikibaseIntegrator()
 
@@ -12,12 +18,13 @@ wbi = WikibaseIntegrator()
 class TestEntityLexeme(unittest.TestCase):
 
     def test_get(self):
+        lexeme_numeric_id = int(LEXEME_MAIN_ID.lstrip('L'))
         # Test with complete id
-        assert wbi.lexeme.get('L5').id == 'L5'
+        assert wbi.lexeme.get(LEXEME_MAIN_ID).id == LEXEME_MAIN_ID
         # Test with numeric id as string
-        assert wbi.lexeme.get('5').id == 'L5'
+        assert wbi.lexeme.get(str(lexeme_numeric_id)).id == LEXEME_MAIN_ID
         # Test with numeric id as int
-        assert wbi.lexeme.get(5).id == 'L5'
+        assert wbi.lexeme.get(lexeme_numeric_id).id == LEXEME_MAIN_ID
 
         # Test with invalid id
         with self.assertRaises(ValueError):
@@ -32,15 +39,17 @@ class TestEntityLexeme(unittest.TestCase):
             wbi.lexeme.get(-1)
 
     def test_get_json(self):
-        assert wbi.lexeme.get('L5').get_json()['forms'][0]['representations']['es']['value'] == 'pinos'
+        assert wbi.lexeme.get(LEXEME_MAIN_ID).get_json()['forms'][0]['representations']['es']['value']
 
     def test_long_item_id(self):
-        assert wbi.lexeme.get('Lexeme:L582').id == 'L582'
+        assert wbi.lexeme.get(f'Lexeme:{LEXEME_MAIN_ID}').id == LEXEME_MAIN_ID
 
     def test_entity_url(self):
-        assert wbi.lexeme.new(id='L582').get_entity_url() == 'http://www.wikidata.org/entity/L582'
-        assert wbi.lexeme.new(id='582').get_entity_url() == 'http://www.wikidata.org/entity/L582'
-        assert wbi.lexeme.new(id=582).get_entity_url() == 'http://www.wikidata.org/entity/L582'
+        lexeme_numeric_id = int(LEXEME_MAIN_ID.lstrip('L'))
+        expected_url = f"{wbi_config['WIKIBASE_URL']}/entity/{LEXEME_MAIN_ID}"
+        assert wbi.lexeme.new(id=LEXEME_MAIN_ID).get_entity_url() == expected_url
+        assert wbi.lexeme.new(id=str(lexeme_numeric_id)).get_entity_url() == expected_url
+        assert wbi.lexeme.new(id=lexeme_numeric_id).get_entity_url() == expected_url
 
     # Test if the language is correctly formatted (T338255)
     def test_wrong_language(self):
@@ -57,21 +66,14 @@ class TestEntityLexeme(unittest.TestCase):
     def test_get_forms(self):
         lexeme = wbi.lexeme.new()
 
-        form = Form(form_id='L5-F4')
+        form = Form(form_id=f'{LEXEME_MAIN_ID}-F4')
         form.representations.set(language='en', value='English form representation')
         form.representations.set(language='fr', value='French form representation')
         claim = datatypes.String(prop_nr='P828', value="Create a string claim for form")
         form.claims.add(claim)
         lexeme.forms.add(form)
 
-        form = Form(form_id='L5-F5')
-        form.representations.set(language='en', value='English form representation')
-        form.representations.set(language='fr', value='French form representation')
-        claim = datatypes.String(prop_nr='P828', value="Create a string claim for form")
-        form.claims.add(claim)
-        lexeme.forms.add(form)
-
-        form = Form()
+        form = Form(form_id=f'{LEXEME_MAIN_ID}-F5')
         form.representations.set(language='en', value='English form representation')
         form.representations.set(language='fr', value='French form representation')
         claim = datatypes.String(prop_nr='P828', value="Create a string claim for form")
@@ -85,6 +87,13 @@ class TestEntityLexeme(unittest.TestCase):
         form.claims.add(claim)
         lexeme.forms.add(form)
 
-        assert not lexeme.forms.get('L5-F3')
-        assert lexeme.forms.get('L5-F4') and lexeme.forms.get('L5-F5')
+        form = Form()
+        form.representations.set(language='en', value='English form representation')
+        form.representations.set(language='fr', value='French form representation')
+        claim = datatypes.String(prop_nr='P828', value="Create a string claim for form")
+        form.claims.add(claim)
+        lexeme.forms.add(form)
+
+        assert not lexeme.forms.get(f'{LEXEME_MAIN_ID}-F3')
+        assert lexeme.forms.get(f'{LEXEME_MAIN_ID}-F4') and lexeme.forms.get(f'{LEXEME_MAIN_ID}-F5')
         assert len(lexeme.forms) == 4

--- a/test/test_entity_mediainfo.py
+++ b/test/test_entity_mediainfo.py
@@ -1,9 +1,14 @@
 import unittest
 
+import pytest
+
+from test.wikibase_test_config import MEDIAINFO_MAIN_ID
 from wikibaseintegrator import WikibaseIntegrator
 from wikibaseintegrator.wbi_config import config as wbi_config
 
 wbi = WikibaseIntegrator()
+
+pytestmark = [pytest.mark.external_network, pytest.mark.wikibase_integration, pytest.mark.requires_commons]
 
 
 class TestEntityMediaInfo(unittest.TestCase):
@@ -34,12 +39,13 @@ class TestEntityMediaInfo(unittest.TestCase):
             wbi_config.pop('MEDIAWIKI_API_URL', None)
 
     def test_get(self):
+        mediainfo_numeric_id = int(MEDIAINFO_MAIN_ID.lstrip('M'))
         # Test with complete id
-        assert wbi.mediainfo.get('M75908279').id == 'M75908279'
+        assert wbi.mediainfo.get(MEDIAINFO_MAIN_ID).id == MEDIAINFO_MAIN_ID
         # Test with numeric id as string
-        assert wbi.mediainfo.get('75908279').id == 'M75908279'
+        assert wbi.mediainfo.get(str(mediainfo_numeric_id)).id == MEDIAINFO_MAIN_ID
         # Test with numeric id as int
-        assert wbi.mediainfo.get(75908279).id == 'M75908279'
+        assert wbi.mediainfo.get(mediainfo_numeric_id).id == MEDIAINFO_MAIN_ID
 
         # Test with invalid id
         with self.assertRaises(ValueError):
@@ -54,19 +60,21 @@ class TestEntityMediaInfo(unittest.TestCase):
             wbi.mediainfo.get(-1)
 
     def test_get_json(self):
-        assert wbi.mediainfo.get('M75908279').get_json()
+        assert wbi.mediainfo.get(MEDIAINFO_MAIN_ID).get_json()
 
     def test_entity_url(self):
-        assert wbi.mediainfo.new(id='M75908279').get_entity_url() == 'https://commons.wikimedia.org/entity/M75908279'
-        assert wbi.mediainfo.new(id='75908279').get_entity_url() == 'https://commons.wikimedia.org/entity/M75908279'
-        assert wbi.mediainfo.new(id=75908279).get_entity_url() == 'https://commons.wikimedia.org/entity/M75908279'
+        mediainfo_numeric_id = int(MEDIAINFO_MAIN_ID.lstrip('M'))
+        expected_url = f"https://commons.wikimedia.org/entity/{MEDIAINFO_MAIN_ID}"
+        assert wbi.mediainfo.new(id=MEDIAINFO_MAIN_ID).get_entity_url() == expected_url
+        assert wbi.mediainfo.new(id=str(mediainfo_numeric_id)).get_entity_url() == expected_url
+        assert wbi.mediainfo.new(id=mediainfo_numeric_id).get_entity_url() == expected_url
 
     # Test if we can read the claims/statements of the entity
     def test_entity_claims(self):
-        media = wbi.mediainfo.get('M75908279')
+        media = wbi.mediainfo.get(MEDIAINFO_MAIN_ID)
         assert media.claims
 
     # Test if we can have the statements field in the json
     def test_get_statements(self):
-        media = wbi.mediainfo.get('M75908279')
+        media = wbi.mediainfo.get(MEDIAINFO_MAIN_ID)
         assert media.get_json()['statements']

--- a/test/test_entity_mediainfo.py
+++ b/test/test_entity_mediainfo.py
@@ -1,8 +1,8 @@
 import unittest
+from test.wikibase_test_config import MEDIAINFO_MAIN_ID
 
 import pytest
 
-from test.wikibase_test_config import MEDIAINFO_MAIN_ID
 from wikibaseintegrator import WikibaseIntegrator
 from wikibaseintegrator.wbi_config import config as wbi_config
 

--- a/test/test_entity_property.py
+++ b/test/test_entity_property.py
@@ -1,8 +1,8 @@
 import unittest
+from test.wikibase_test_config import PROPERTY_AUTHOR_ID, configure_endpoints_from_env
 
 import pytest
 
-from test.wikibase_test_config import PROPERTY_AUTHOR_ID, configure_endpoints_from_env
 from wikibaseintegrator import WikibaseIntegrator
 from wikibaseintegrator.wbi_config import config as wbi_config
 

--- a/test/test_entity_property.py
+++ b/test/test_entity_property.py
@@ -1,9 +1,15 @@
 import unittest
 
+import pytest
+
+from test.wikibase_test_config import PROPERTY_AUTHOR_ID, configure_endpoints_from_env
 from wikibaseintegrator import WikibaseIntegrator
 from wikibaseintegrator.wbi_config import config as wbi_config
 
 wbi_config['USER_AGENT'] = 'WikibaseIntegrator-pytest/1.0 (test_entity_property.py)'
+configure_endpoints_from_env()
+
+pytestmark = [pytest.mark.external_network, pytest.mark.wikibase_integration]
 
 wbi = WikibaseIntegrator()
 
@@ -11,12 +17,13 @@ wbi = WikibaseIntegrator()
 class TestEntityProperty(unittest.TestCase):
 
     def test_get(self):
+        property_numeric_id = int(PROPERTY_AUTHOR_ID.lstrip('P'))
         # Test with complete id
-        assert wbi.property.get('P50').id == 'P50'
+        assert wbi.property.get(PROPERTY_AUTHOR_ID).id == PROPERTY_AUTHOR_ID
         # Test with numeric id as string
-        assert wbi.property.get('50').id == 'P50'
+        assert wbi.property.get(str(property_numeric_id)).id == PROPERTY_AUTHOR_ID
         # Test with numeric id as int
-        assert wbi.property.get(50).id == 'P50'
+        assert wbi.property.get(property_numeric_id).id == PROPERTY_AUTHOR_ID
 
         # Test with invalid id
         with self.assertRaises(ValueError):
@@ -31,15 +38,17 @@ class TestEntityProperty(unittest.TestCase):
             wbi.property.get(-1)
 
     def test_get_json(self):
-        assert wbi.property.get('P50', mediawiki_api_url='https://commons.wikimedia.org/w/api.php').get_json()['labels']['fr']['value'] == 'auteur ou autrice'
+        assert wbi.property.get(PROPERTY_AUTHOR_ID).get_json()['labels']['fr']['value']
 
     def test_create_property(self):
         wbi.property.new(datatype='wikibase-item')
 
     def test_long_item_id(self):
-        assert wbi.property.get('Property:P582').id == 'P582'
+        assert wbi.property.get(f'Property:{PROPERTY_AUTHOR_ID}').id == PROPERTY_AUTHOR_ID
 
     def test_entity_url(self):
-        assert wbi.property.new(id='P582').get_entity_url() == 'http://www.wikidata.org/entity/P582'
-        assert wbi.property.new(id='582').get_entity_url() == 'http://www.wikidata.org/entity/P582'
-        assert wbi.property.new(id=582).get_entity_url() == 'http://www.wikidata.org/entity/P582'
+        property_numeric_id = int(PROPERTY_AUTHOR_ID.lstrip('P'))
+        expected_url = f"{wbi_config['WIKIBASE_URL']}/entity/{PROPERTY_AUTHOR_ID}"
+        assert wbi.property.new(id=PROPERTY_AUTHOR_ID).get_entity_url() == expected_url
+        assert wbi.property.new(id=str(property_numeric_id)).get_entity_url() == expected_url
+        assert wbi.property.new(id=property_numeric_id).get_entity_url() == expected_url

--- a/test/test_wbi_core.py
+++ b/test/test_wbi_core.py
@@ -1,6 +1,9 @@
 import unittest
 from copy import deepcopy
 
+import pytest
+
+from test.wikibase_test_config import configure_endpoints_from_env
 from wikibaseintegrator import WikibaseIntegrator
 from wikibaseintegrator.datatypes import (URL, CommonsMedia, ExternalID, Form, GeoShape, GlobeCoordinate, Item, Lexeme, Math, MonolingualText, MusicalNotation, Property, Quantity,
                                           Sense, String, TabularData, Time)
@@ -12,6 +15,9 @@ from wikibaseintegrator.wbi_enums import ActionIfExists, WikibaseRank, WikibaseS
 from wikibaseintegrator.wbi_helpers import generate_entity_instances, search_entities
 
 wbi_config['USER_AGENT'] = 'WikibaseIntegrator-pytest/1.0 (test_wbi_core.py)'
+configure_endpoints_from_env()
+
+pytestmark = [pytest.mark.external_network, pytest.mark.wikibase_integration]
 
 wbi = WikibaseIntegrator()
 

--- a/test/test_wbi_core.py
+++ b/test/test_wbi_core.py
@@ -1,9 +1,9 @@
 import unittest
 from copy import deepcopy
+from test.wikibase_test_config import configure_endpoints_from_env
 
 import pytest
 
-from test.wikibase_test_config import configure_endpoints_from_env
 from wikibaseintegrator import WikibaseIntegrator
 from wikibaseintegrator.datatypes import (URL, CommonsMedia, ExternalID, Form, GeoShape, GlobeCoordinate, Item, Lexeme, Math, MonolingualText, MusicalNotation, Property, Quantity,
                                           Sense, String, TabularData, Time)

--- a/test/test_wbi_fastrun.py
+++ b/test/test_wbi_fastrun.py
@@ -1,12 +1,18 @@
 from collections import defaultdict
 from typing import Any
 
+import pytest
+
+from test.wikibase_test_config import configure_endpoints_from_env
 from wikibaseintegrator import WikibaseIntegrator, wbi_fastrun
 from wikibaseintegrator.datatypes import BaseDataType, ExternalID, Item
 from wikibaseintegrator.wbi_config import config as wbi_config
 from wikibaseintegrator.wbi_enums import ActionIfExists
 
 wbi_config['USER_AGENT'] = 'WikibaseIntegrator-pytest/1.0 (test_wbi_fastrun.py)'
+configure_endpoints_from_env()
+
+pytestmark = [pytest.mark.external_network, pytest.mark.wikibase_integration, pytest.mark.requires_sparql]
 
 wbi = WikibaseIntegrator()
 

--- a/test/test_wbi_fastrun.py
+++ b/test/test_wbi_fastrun.py
@@ -1,9 +1,9 @@
 from collections import defaultdict
+from test.wikibase_test_config import configure_endpoints_from_env
 from typing import Any
 
 import pytest
 
-from test.wikibase_test_config import configure_endpoints_from_env
 from wikibaseintegrator import WikibaseIntegrator, wbi_fastrun
 from wikibaseintegrator.datatypes import BaseDataType, ExternalID, Item
 from wikibaseintegrator.wbi_config import config as wbi_config

--- a/test/test_wbi_helpers.py
+++ b/test/test_wbi_helpers.py
@@ -1,10 +1,10 @@
 import logging
 import os
+from test.wikibase_test_config import ITEM_CITY_ID, configure_endpoints_from_env
 
 import pytest
 import requests
 
-from test.wikibase_test_config import ITEM_CITY_ID, configure_endpoints_from_env
 from wikibaseintegrator.wbi_config import config as wbi_config
 from wikibaseintegrator.wbi_exceptions import MaxRetriesReachedException
 from wikibaseintegrator.wbi_helpers import execute_sparql_query, format2wbi, get_user_agent, mediawiki_api_call_helper

--- a/test/test_wbi_helpers.py
+++ b/test/test_wbi_helpers.py
@@ -1,18 +1,22 @@
 import logging
 import os
-import unittest
 
 import pytest
 import requests
 
+from test.wikibase_test_config import ITEM_CITY_ID, configure_endpoints_from_env
 from wikibaseintegrator.wbi_config import config as wbi_config
 from wikibaseintegrator.wbi_exceptions import MaxRetriesReachedException
 from wikibaseintegrator.wbi_helpers import execute_sparql_query, format2wbi, get_user_agent, mediawiki_api_call_helper
 
+configure_endpoints_from_env()
+
+pytestmark = [pytest.mark.external_network, pytest.mark.wikibase_integration]
+
 
 def test_connection():
     wbi_config['USER_AGENT'] = 'WikibaseIntegrator-pytest/1.0 (test_wbi_helpers.py)'
-    data = {'format': 'json', 'action': 'wbgetentities', 'ids': 'Q42'}
+    data = {'format': 'json', 'action': 'wbgetentities', 'ids': ITEM_CITY_ID}
 
     mediawiki_api_call_helper(data=data, max_retries=2, retry_after=1, allow_anonymous=True)
 
@@ -39,13 +43,13 @@ def test_user_agent(caplog):
     wbi_config['USER_AGENT'] = None  # Reset user agent
     # Test there is no warning because of the user agent
     with caplog.at_level(logging.WARNING):
-        mediawiki_api_call_helper(data={'format': 'json', 'action': 'wbgetentities', 'ids': 'Q42'}, max_retries=3, retry_after=1, allow_anonymous=True,
+        mediawiki_api_call_helper(data={'format': 'json', 'action': 'wbgetentities', 'ids': ITEM_CITY_ID}, max_retries=3, retry_after=1, allow_anonymous=True,
                                   user_agent='MyWikibaseBot/0.5')
     assert 'WARNING' not in caplog.text
 
     # Test there is a warning
     with caplog.at_level(logging.WARNING):
-        mediawiki_api_call_helper(data={'format': 'json', 'action': 'wbgetentities', 'ids': 'Q42'}, max_retries=3, retry_after=1, allow_anonymous=True)
+        mediawiki_api_call_helper(data={'format': 'json', 'action': 'wbgetentities', 'ids': ITEM_CITY_ID}, max_retries=3, retry_after=1, allow_anonymous=True)
     assert 'Please set an user agent' in caplog.text
 
     # Test if the user agent is correctly added
@@ -58,13 +62,14 @@ def test_allow_anonymous():
     wbi_config['USER_AGENT'] = 'WikibaseIntegrator-pytest/1.0 (test_wbi_helpers.py)'
     # Test there is a warning because of allow_anonymous
     with pytest.raises(ValueError):
-        mediawiki_api_call_helper(data={'format': 'json', 'action': 'wbgetentities', 'ids': 'Q42'}, max_retries=3, retry_after=1, user_agent='MyWikibaseBot/0.5')
+        mediawiki_api_call_helper(data={'format': 'json', 'action': 'wbgetentities', 'ids': ITEM_CITY_ID}, max_retries=3, retry_after=1, user_agent='MyWikibaseBot/0.5')
 
     # Test there is no warning because of allow_anonymous
-    assert mediawiki_api_call_helper(data={'format': 'json', 'action': 'wbgetentities', 'ids': 'Q42'}, max_retries=3, retry_after=1, allow_anonymous=True,
+    assert mediawiki_api_call_helper(data={'format': 'json', 'action': 'wbgetentities', 'ids': ITEM_CITY_ID}, max_retries=3, retry_after=1, allow_anonymous=True,
                                      user_agent='MyWikibaseBot/0.5')
 
 
+@pytest.mark.requires_sparql
 def test_sparql():
     wbi_config['USER_AGENT'] = 'WikibaseIntegrator-pytest/1.0 (test_wbi_helpers.py)'
     results = execute_sparql_query('''SELECT ?child ?childLabel

--- a/test/test_wbi_login.py
+++ b/test/test_wbi_login.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import unittest
 
 import pytest
 import requests
@@ -10,6 +9,8 @@ from wikibaseintegrator import wbi_login
 from wikibaseintegrator.wbi_helpers import mediawiki_api_call_helper
 # look for environment variables. if none set, don't do anything
 from wikibaseintegrator.wbi_login import LoginError
+
+pytestmark = [pytest.mark.external_network, pytest.mark.wikibase_integration]
 
 WDUSER = os.getenv("WDUSER")
 WDPASS = os.getenv("WDPASS")

--- a/test/wikibase_test_config.py
+++ b/test/wikibase_test_config.py
@@ -1,0 +1,30 @@
+import os
+from typing import Final
+
+from wikibaseintegrator.wbi_config import config as wbi_config
+
+# Centralized IDs so tests can run against either Wikidata defaults or a seeded local Wikibase.
+ITEM_EARTH_ID: Final[str] = os.getenv('WBI_TEST_ITEM_EARTH_ID', 'Q2')
+ITEM_CITY_ID: Final[str] = os.getenv('WBI_TEST_ITEM_CITY_ID', 'Q582')
+ITEM_GENE_ID: Final[str] = os.getenv('WBI_TEST_ITEM_GENE_ID', 'Q10874')
+ITEM_SITELINK_ID: Final[str] = os.getenv('WBI_TEST_ITEM_SITELINK_ID', 'Q622901')
+ITEM_NO_SITELINK_ID: Final[str] = os.getenv('WBI_TEST_ITEM_NO_SITELINK_ID', 'Q27869338')
+PROPERTY_AUTHOR_ID: Final[str] = os.getenv('WBI_TEST_PROPERTY_AUTHOR_ID', 'P50')
+LEXEME_MAIN_ID: Final[str] = os.getenv('WBI_TEST_LEXEME_MAIN_ID', 'L5')
+MEDIAINFO_MAIN_ID: Final[str] = os.getenv('WBI_TEST_MEDIAINFO_MAIN_ID', 'M75908279')
+
+
+def configure_endpoints_from_env() -> None:
+    """Override default endpoints for tests when local Wikibase env vars are set."""
+    endpoint_mapping = {
+        'WBI_MEDIAWIKI_API_URL': 'MEDIAWIKI_API_URL',
+        'WBI_MEDIAWIKI_INDEX_URL': 'MEDIAWIKI_INDEX_URL',
+        'WBI_MEDIAWIKI_REST_URL': 'MEDIAWIKI_REST_URL',
+        'WBI_SPARQL_ENDPOINT_URL': 'SPARQL_ENDPOINT_URL',
+        'WBI_WIKIBASE_URL': 'WIKIBASE_URL'
+    }
+
+    for env_name, config_key in endpoint_mapping.items():
+        env_value = os.getenv(env_name)
+        if env_value:
+            wbi_config[config_key] = env_value

--- a/wikibaseintegrator/wbi_config.py
+++ b/wikibaseintegrator/wbi_config.py
@@ -12,6 +12,8 @@ USER_AGENT:        Complementary user agent string used for http requests. Both 
                    See: https://foundation.wikimedia.org/wiki/Policy:User-Agent_policy
 """
 
+import os
+
 config: dict[str, str | int | None | bool] = {
     'BACKOFF_MAX_TRIES': 5,
     'BACKOFF_MAX_VALUE': 3600,
@@ -20,11 +22,11 @@ config: dict[str, str | int | None | bool] = {
     'DISTINCT_VALUES_CONSTRAINT_QID': 'Q21502410',
     'COORDINATE_GLOBE_QID': 'http://www.wikidata.org/entity/Q2',
     'CALENDAR_MODEL_QID': 'http://www.wikidata.org/entity/Q1985727',
-    'MEDIAWIKI_API_URL': 'https://www.wikidata.org/w/api.php',
-    'MEDIAWIKI_INDEX_URL': 'https://www.wikidata.org/w/index.php',
-    'MEDIAWIKI_REST_URL': 'https://www.wikidata.org/w/rest.php',
-    'SPARQL_ENDPOINT_URL': 'https://query.wikidata.org/sparql',
-    'WIKIBASE_URL': 'http://www.wikidata.org',
+    'MEDIAWIKI_API_URL': os.getenv('WBI_MEDIAWIKI_API_URL', 'https://www.wikidata.org/w/api.php'),
+    'MEDIAWIKI_INDEX_URL': os.getenv('WBI_MEDIAWIKI_INDEX_URL', 'https://www.wikidata.org/w/index.php'),
+    'MEDIAWIKI_REST_URL': os.getenv('WBI_MEDIAWIKI_REST_URL', 'https://www.wikidata.org/w/rest.php'),
+    'SPARQL_ENDPOINT_URL': os.getenv('WBI_SPARQL_ENDPOINT_URL', 'https://query.wikidata.org/sparql'),
+    'WIKIBASE_URL': os.getenv('WBI_WIKIBASE_URL', 'http://www.wikidata.org'),
     'DEFAULT_LANGUAGE': 'en',
     'DEFAULT_LEXEME_LANGUAGE': 'Q1860'
 }


### PR DESCRIPTION
Introduce a local Wikibase integration test lane and make tests endpoint-configurable. Adds .github/wikibase-ci (docker-compose, API wait and seed scripts), updates GitHub Actions to include a unit job and a workflow_dispatch "wikibase-local" job that starts a local Wikibase, seeds deterministic entities and runs a subset of integration tests. Add pytest markers and a conftest to skip external-network/wikibase integration tests by default, and centralize test IDs/endpoints in test/wikibase_test_config.py. Update pyproject.toml with new markers and modify many tests to use the centralized IDs. Make wbi_config read endpoint-related env vars so tests can target either Wikidata or a local Wikibase instance.