### PR TITLE
Update CI configuration to use Ubuntu 24.04 container

### DIFF
--- a/.github/workflows/python-pytest.yaml
+++ b/.github/workflows/python-pytest.yaml
@@ -21,7 +21,7 @@ jobs:
   build:
     name: pytest ${{ matrix.python-version }}
     runs-on: ubuntu-latest
-    container: ubuntu
+    container: ubuntu:24.04
 
     services:
       httpstatus:


### PR DESCRIPTION
This pull request updates the container image used in the GitHub Actions workflow for running Python tests to ensure a more specific and up-to-date environment.

CI/CD workflow update:

* Changed the `container` in `.github/workflows/python-pytest.yaml` from `ubuntu` to `ubuntu:24.04` to explicitly use the latest Ubuntu LTS version for test runs.