### PR TITLE
Avoid mutating passed-in request data

### DIFF
--- a/wikibaseintegrator/wbi_helpers.py
+++ b/wikibaseintegrator/wbi_helpers.py
@@ -66,6 +66,7 @@ def mediawiki_api_call(method: str, mediawiki_api_url: str | None = None, sessio
     # TODO: Add support for 'multipart/form-data' when using POST (https://www.mediawiki.org/wiki/API:Edit#Large_edits)
 
     if 'data' in kwargs and kwargs['data']:
+        kwargs['data'] = dict(kwargs['data'])
         if 'format' not in kwargs['data']:
             kwargs['data'].update({'format': 'json'})
         elif kwargs['data']['format'] != 'json':
@@ -165,6 +166,7 @@ def mediawiki_api_call_helper(data: dict[str, Any], login: _Login | None = None,
     """
     mediawiki_api_url = str(mediawiki_api_url or config['MEDIAWIKI_API_URL'])
     user_agent = user_agent or (str(config['USER_AGENT']) if config['USER_AGENT'] is not None else None)
+    data = data.copy()
 
     hostname = urlparse(mediawiki_api_url).hostname
     if hostname is not None and hostname.endswith(('wikidata.org', 'wikipedia.org', 'wikimedia.org')) and user_agent is None:


### PR DESCRIPTION
Convert and copy incoming request payloads to prevent accidental mutation of caller-provided mappings. In mediawiki_api_call, kwargs['data'] is wrapped with dict(...) so updates (like adding format) work for non-dict mappings and don't modify the original. In mediawiki_api_call_helper, data is shallow-copied before use to avoid side effects when modifying the payload. This makes API helper functions safer when callers pass in shared or immutable mapping types.