### PR TITLE
Rename params to body in execute_sparql_query

### DIFF
--- a/wikibaseintegrator/wbi_helpers.py
+++ b/wikibaseintegrator/wbi_helpers.py
@@ -274,7 +274,7 @@ def execute_sparql_query(query: str, prefix: str | None = None, endpoint: str | 
     if prefix:
         query = prefix + '\n' + query
 
-    params = {
+    body = {
         'query': '#Tool: WikibaseIntegrator wbi_functions.execute_sparql_query\n' + query,
         'format': 'json'
     }
@@ -287,11 +287,11 @@ def execute_sparql_query(query: str, prefix: str | None = None, endpoint: str | 
         'User-Agent': get_user_agent(user_agent)
     }
 
-    log.debug("SPARQL query:\n%s", params['query'])
+    log.debug("SPARQL query:\n%s", body['query'])
 
     for _ in range(max_retries):
         try:
-            response = helpers_session.post(sparql_endpoint_url, data=params, headers=headers, timeout=config['TIMEOUT'])
+            response = helpers_session.post(sparql_endpoint_url, data=body, headers=headers, timeout=config['TIMEOUT'])
         except requests.exceptions.ConnectionError as e:
             log.exception("Connection error: %s. Sleeping for %d seconds.", e, retry_after)
             sleep(retry_after)


### PR DESCRIPTION
Rename the local `params` dict to `body` in `execute_sparql_query`, since the SPARQL query is sent in the POST body (`data=`), not as URL parameters. Updates the dict declaration, the debug log and the `helpers_session.post(..., data=body, ...)` call.

The functional fix originally in this PR (sending the query with `data=` instead of `params=`, dropping the incorrect `multipart/form-data` Content-Type) already landed in master via #1030. After rebasing, only this cosmetic rename remains; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
