### PR TITLE
Add .run/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ fabric.properties
 
 # Other stuff
 /drafts/
+/.run/


### PR DESCRIPTION
The .run/ directory is created by JetBrains IDEs (PyCharm, IntelliJ, etc.) to store run configurations. These are IDE-specific and should not be committed to the repository.