### PR TITLE
Fix fastrun bugs, resolve TODOs and update the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -936,8 +936,9 @@ frc.check_language_data(qid=qid, lang_data=['CDK7'], lang='en', lang_data_type='
   until the next run.
 * The whole data corpus selected by the base filter is loaded in memory. Choose a base filter that selects a reasonably
   sized subset of the instance.
-* Some datatypes are only partially supported when used as qualifiers or references (e.g. Time, GlobeCoordinate,
-  MonolingualText): entities using them may always be reported as requiring a write.
+* The statement attributes that are not exposed in the SPARQL simple values (time precision, globe coordinate
+  precision, quantity bounds...) are reconstructed with their default values: statements using non-default values for
+  these attributes are always reported as requiring a write.
 
 # Debugging #
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ wikibaseintegrator~=0.11.3
     - [Modify an existing item](#modify-an-existing-item)
     - [A bot for Mass Import](#a-bot-for-mass-import)
 - [Examples (in "fast run" mode)](#examples-in-fast-run-mode)
+    - [The base filter](#the-base-filter)
+    - [Checking if a write is required](#checking-if-a-write-is-required)
+    - [Options](#options)
+    - [Checking labels, descriptions and aliases](#checking-labels-descriptions-and-aliases)
+    - [Limitations](#limitations)
 - [Debugging](#debugging)
 
 # WikibaseIntegrator / WikidataIntegrator #
@@ -91,7 +96,8 @@ The main differences between these two libraries are :
 * Add OAuth 2.0 login method
 * Add logging module support
 
-But WikibaseIntegrator lack the "fastrun" functionality implemented in WikidataIntegrator.
+WikibaseIntegrator also provides a rewritten version of the "fast run" mode of WikidataIntegrator, which avoids
+unnecessary API writes (see [Examples (in "fast run" mode)](#examples-in-fast-run-mode)).
 
 # Documentation #
 
@@ -799,21 +805,35 @@ for entrez_id, ensembl in raw_data.items():
 
 # Examples (in "fast run" mode) #
 
+The fast run mode is designed for bots synchronising an external resource with a Wikibase instance, where most of the
+entities are usually already up to date. Instead of loading every entity through the MediaWiki API to compare it with
+the local data, the fast run mode preloads the current state of all the entities of the data corpus with a few paginated
+SPARQL queries, then decides locally, entity per entity, if a write is required. When nothing changed (the most common
+case), no MediaWiki API call is made at all for that entity.
+
 In order to use the fast run mode, you need to know the property/value combination which determines the data corpus you
 would like to operate on. E.g. for operating on human genes, you need to know
 that [P351](https://www.wikidata.org/entity/P351) is the NCBI Entrez Gene ID and you also need to know that you are
 dealing with humans, best represented by the [found in taxon property (P703)](https://www.wikidata.org/entity/P703) with
 the value [Q15978631](https://www.wikidata.org/entity/Q15978631) for Homo sapiens.
 
-IMPORTANT: In order for the fast run mode to work, the data you provide in the constructor must contain at least one
-unique value/id only present on one Wikidata element, e.g. an NCBI entrez gene ID, Uniprot ID, etc. Usually, these would
-be the same unique core properties used for defining domains in wbi_core, e.g. for genes, proteins, drugs or your custom
-domains.
+IMPORTANT: In order for the fast run mode to work on entities without a known entity ID, the data you provide must
+contain at least one unique value/id only present on one Wikibase entity, e.g. an NCBI entrez gene ID, Uniprot ID, etc.
+This unique value is used to identify the target entity. If the entity ID is already known (e.g. the entity was loaded
+with `wbi.item.get()`), this requirement does not apply.
 
-Below, the normal mode run example from above, slightly modified, to meet the requirements for the fast run mode. To
-enable it, ItemEngine requires two parameters, fast_run=True/False and fast_run_base_filter which is a dictionary
-holding the properties to filter for as keys, and the item QIDs as dict values. If the value is not a QID but a literal,
-just provide an empty string. For the above example, the dictionary looks like this:
+## The base filter ##
+
+The base filter defines the data corpus and is a list of datatype instances (the same classes used to create claims).
+Three forms are supported:
+
+* A property with a value: the entities must have this exact statement, e.g. `Item(prop_nr='P703', value='Q15978631')`
+  (found in taxon Homo sapiens).
+* A property without a value: the entities must have a statement with this property, whatever the value, e.g.
+  `ExternalID(prop_nr='P351')` (any NCBI Entrez Gene ID).
+* A property path, given as a list of two datatype instances: the value is reached through the first property followed
+  by any number of hops with the second one, e.g. `[Item(prop_nr='P31', value='Q11173'), Item(prop_nr='P279')]`
+  (instance of (P31) chemical compound (Q11173), directly or through a chain of subclass of (P279)).
 
 ```python
 from wikibaseintegrator.datatypes import ExternalID, Item
@@ -821,20 +841,25 @@ from wikibaseintegrator.datatypes import ExternalID, Item
 fast_run_base_filter = [ExternalID(prop_nr='P351'), Item(prop_nr='P703', value='Q15978631')]
 ```
 
-The full example:
+## Checking if a write is required ##
+
+The entry point is `entity.write_required()`. It returns `True` if the local entity differs from the live data and an
+actual write is needed, `False` if the entity is already up to date and the write can be skipped. The full example, a
+modified version of the mass import bot from the normal mode example:
 
 ```python
 from wikibaseintegrator import WikibaseIntegrator, wbi_login
-from wikibaseintegrator.datatypes import ExternalID, Item, String, Time
+from wikibaseintegrator.datatypes import ExternalID, Item, Time
 from wikibaseintegrator.wbi_enums import WikibaseTimePrecision
 
 # login object
 login = wbi_login.OAuth2(consumer_token='<consumer_token>', consumer_secret='<consumer_secret>')
 
-fast_run_base_filter = [ExternalID(prop_nr='P351'), Item(prop_nr='P703', value='Q15978631')]
-fast_run = True
+wbi = WikibaseIntegrator(login=login)
 
-# We have raw data, which should be written to Wikidata, namely two human NCBI entrez gene IDs mapped to two Ensembl Gene IDs
+fast_run_base_filter = [ExternalID(prop_nr='P351'), ExternalID(prop_nr='P704'), Item(prop_nr='P703', value='Q15978631')]
+
+# We have raw data, which should be written to Wikidata, namely two human NCBI entrez gene IDs mapped to two Ensembl transcript IDs
 # You can iterate over any data source as long as you can map the values to Wikidata properties.
 raw_data = {
     '50943': 'ENST00000376197',
@@ -845,31 +870,74 @@ for entrez_id, ensembl in raw_data.items():
     # add some references
     references = [
         [
-            Item(value='Q20641742', prop_nr='P248')
-        ],
-        [
-            Time(time='+2020-02-08T00:00:00Z', prop_nr='P813', precision=WikibaseTimePrecision.DAY),
-            ExternalID(value='1017', prop_nr='P351')
+            Item(value='Q20641742', prop_nr='P248'),
+            Time(time='+2020-02-08T00:00:00Z', prop_nr='P813', precision=WikibaseTimePrecision.DAY)
         ]
     ]
 
-    # data type object
-    entrez_gene_id = String(value=entrez_id, prop_nr='P351', references=references)
-    ensembl_transcript_id = String(value=ensembl, prop_nr='P704', references=references)
+    # data type objects
+    entrez_gene_id = ExternalID(value=entrez_id, prop_nr='P351', references=references)
+    ensembl_transcript_id = ExternalID(value=ensembl, prop_nr='P704', references=references)
 
     # data goes into a list, because many data objects can be provided to
     data = [entrez_gene_id, ensembl_transcript_id]
 
-    # Search for and then edit/create new item
-    wb_item = WikibaseIntegrator(login=login).item.new()
-    wb_item.add_claims(claims=data)
-    wb_item.init_fastrun(base_filter=fast_run_base_filter)
-    wb_item.write()
+    item = wbi.item.new()
+    item.claims.add(data)
+
+    # Compare the local data with the live data and only write when something differs
+    if item.write_required(base_filter=fast_run_base_filter):
+        item.write()
 ```
 
-Note: Fastrun mode checks for equality of property/value pairs, qualifiers (not including qualifier attributes), labels,
-aliases and description, but it ignores references by default!
-References can be checked in fast run mode by setting `use_refs` to `True`.
+Note: only the claims whose property appears in the base filter are compared. In the example above, the P351 and P704
+claims are checked because both properties are part of the base filter; a claim on any other property would be ignored
+by the comparison.
+
+## Options ##
+
+`write_required()` accepts optional parameters:
+
+* `use_refs` (default `False`): also compare the references of the statements. By default, references are ignored.
+* `case_insensitive` (default `False`): compare string values case-insensitively.
+* `action_if_exists` (default `ActionIfExists.REPLACE_ALL`): how the local statements are compared with the live ones.
+  With `REPLACE_ALL`, the entity must hold exactly the provided statements for the filtered properties. With
+  `APPEND_OR_REPLACE`, the provided statements must already exist on the entity, but additional existing statements are
+  allowed. With `FORCE_APPEND`, a write is always reported as required.
+
+The preloaded data is shared: containers are cached at the module level and reused by every `write_required()` call
+using the same base filter and options, so the SPARQL queries are only executed once per property.
+
+## Checking labels, descriptions and aliases ##
+
+`write_required()` only compares claims. To check language data (labels, descriptions or aliases), use the fastrun
+container directly:
+
+```python
+from wikibaseintegrator import wbi_fastrun
+from wikibaseintegrator.datatypes import ExternalID, Item
+
+frc = wbi_fastrun.get_fastrun_container(base_filter=[ExternalID(prop_nr='P351'), Item(prop_nr='P703', value='Q15978631')])
+
+# Resolve the entity ID from a unique value, without any MediaWiki API call
+qid = frc.get_item(claims=[ExternalID(value='50943', prop_nr='P351')])
+
+# Returns True if the English label differs from 'CDK7' and a write is required
+frc.check_language_data(qid=qid, lang_data=['CDK7'], lang='en', lang_data_type='label')
+```
+
+`check_language_data()` accepts `'label'`, `'description'` or `'aliases'` as `lang_data_type`, and the same
+`action_if_exists` logic as above (`APPEND_OR_REPLACE` or `REPLACE_ALL`).
+
+## Limitations ##
+
+* The comparison is based on the SPARQL endpoint, which can lag behind the live data (e.g. the Wikidata Query Service
+  replication lag). A decision taken on stale data results, at worst, in one unnecessary write or one missed update
+  until the next run.
+* The whole data corpus selected by the base filter is loaded in memory. Choose a base filter that selects a reasonably
+  sized subset of the instance.
+* Some datatypes are only partially supported when used as qualifiers or references (e.g. Time, GlobeCoordinate,
+  MonolingualText): entities using them may always be reported as requiring a write.
 
 # Debugging #
 

--- a/test/test_datatypes.py
+++ b/test/test_datatypes.py
@@ -87,6 +87,22 @@ class TestTime:
         # Ordering keeps working across the 4/5-digit boundary
         assert Time(time='+9999-01-01T00:00:00Z', prop_nr='P5') < time
 
+    def test_parse_sparql_value(self):
+        # A bare RDF timestamp: the missing '+' is added and the precision is inferred
+        time = Time(prop_nr='P5')
+        assert time.parse_sparql_value('2020-02-08T00:00:00Z') is True
+        assert time.mainsnak.datavalue['value']['time'] == '+2020-02-08T00:00:00Z'
+        assert time.mainsnak.datavalue['value']['precision'] == WikibaseTimePrecision.DAY.value
+
+        # A quoted literal with its datatype suffix
+        time = Time(prop_nr='P5')
+        assert time.parse_sparql_value('"+2020-02-00T00:00:00Z"^^xsd:dateTime') is True
+        assert time.mainsnak.datavalue['value']['precision'] == WikibaseTimePrecision.MONTH.value
+
+        # A timestamp with a time part can't be represented, its precision can't be inferred
+        assert Time(prop_nr='P5').parse_sparql_value('2020-02-08T12:34:56Z') is False
+        assert Time(prop_nr='P5').parse_sparql_value('not a timestamp') is False
+
 
 class TestRank:
     def test_rank_parsing(self):

--- a/test/test_wbi_fastrun.py
+++ b/test/test_wbi_fastrun.py
@@ -10,7 +10,7 @@ from typing import Any
 import pytest
 
 from wikibaseintegrator import WikibaseIntegrator, wbi_fastrun
-from wikibaseintegrator.datatypes import BaseDataType, ExternalID, Item
+from wikibaseintegrator.datatypes import BaseDataType, ExternalID, Item, Quantity
 from wikibaseintegrator.entities import ItemEntity
 from wikibaseintegrator.wbi_enums import ActionIfExists
 
@@ -119,6 +119,21 @@ class TestWriteRequiredEndToEnd:
 
         item.claims.add(ExternalID(value='CHANGED', prop_nr='P352'))
         assert item.write_required(base_filter=[BaseDataType(prop_nr='P352'), Item(prop_nr='P703', value='Q27510868')]) is True
+
+    def test_write_required_quantity(self, wikibase):
+        """
+        Quantity values must round-trip between the SPARQL results and the value lookup.
+
+        Regression: get_items looked up the full SPARQL literal ('"+42"^^xsd:decimal') while the
+        reverse lookup stored plain amounts ('+42'), so a write was always wrongly reported.
+        """
+        wikibase.add_property('P2067', 'quantity')
+        wikibase.sparql_bindings = statement_bindings(wikibase, 'Q42', 'P2067', [literal('42', datatype='http://www.w3.org/2001/XMLSchema#decimal')])
+
+        frc = wbi_fastrun.FastRunContainer(base_filter=[BaseDataType(prop_nr='P2067')], base_data_type=BaseDataType)
+
+        assert frc.write_required(data=[Quantity(amount=42, prop_nr='P2067')]) is False
+        assert frc.write_required(data=[Quantity(amount=43, prop_nr='P2067')]) is True
 
     def test_write_required_with_property_path_base_filter(self, wikibase, item_q582):
         """
@@ -271,6 +286,62 @@ def test_fastrun_ref_ensembl():
     assert not frc.write_required(data=statements)
 
 
+def test_get_items_skips_value_less_claims():
+    """
+    Claims without a value (e.g. deletion objects) must be ignored by the value lookup.
+
+    Regression: they were only skipped when the datatype was also missing, and crashed with a
+    KeyError in get_sparql_value() otherwise.
+    """
+    frc = FastRunContainerFakeQueryDataEnsembl(base_filter=[BaseDataType(prop_nr='P594')], base_data_type=BaseDataType)
+
+    # a value-less claim alone matches nothing
+    assert frc.get_items(claims=[ExternalID(prop_nr='P594')]) is None
+
+    # mixed with a valued claim, the valued claim still matches
+    statements = [ExternalID(value='ENSG00000123374', prop_nr='P594'), ExternalID(prop_nr='P594')]
+    assert frc.get_items(claims=statements) == {'Q14911732'}
+
+
+class FastRunContainerFakeQueryDataCaseInsensitive(wbi_fastrun.FastRunContainer):
+    # an item with a lowercase external identifier
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.prop_dt_map = {'P352': 'external-id'}
+        self.prop_data['Q7758678'] = {'P352': {
+            'fake statement id': {
+                'qual': set(),
+                'ref': {},
+                'unit': '1',
+                'v': '"q9umx9"'}}}
+        self.rev_lookup = defaultdict(set)
+        self.rev_lookup['"q9umx9"'].add('Q7758678')
+        self.rev_lookup_ci = defaultdict(set)
+        self.rev_lookup_ci['"q9umx9"'].add('Q7758678')
+
+
+def test_write_required_case_insensitive():
+    """
+    Regression: with case_insensitive enabled, comparing a statement crashed with an
+    AttributeError (datavalue is a dict) and never matched values differing only by case.
+    """
+    frc = FastRunContainerFakeQueryDataCaseInsensitive(base_filter=[BaseDataType(prop_nr='P352')], base_data_type=BaseDataType, case_insensitive=True)
+
+    # same value with a different case: no write required
+    assert frc.write_required(data=[ExternalID(value='Q9UMX9', prop_nr='P352')]) is False
+    # identical value: no write required
+    assert frc.write_required(data=[ExternalID(value='q9umx9', prop_nr='P352')]) is False
+    # different value: write required
+    assert frc.write_required(data=[ExternalID(value='DIFFERENT', prop_nr='P352')]) is True
+
+
+def test_write_required_case_sensitive_by_default():
+    frc = FastRunContainerFakeQueryDataCaseInsensitive(base_filter=[BaseDataType(prop_nr='P352')], base_data_type=BaseDataType)
+
+    assert frc.write_required(data=[ExternalID(value='Q9UMX9', prop_nr='P352')]) is True
+    assert frc.write_required(data=[ExternalID(value='q9umx9', prop_nr='P352')]) is False
+
+
 class FakeQueryDataAppendProps(wbi_fastrun.FastRunContainer):
     # an item with three values for the same property
     def __init__(self, *args: Any, **kwargs: Any):
@@ -325,3 +396,44 @@ def test_append_props():
     # without append
     statements = [Item(value='Q24784025', prop_nr='P527')]
     assert frc.write_required(data=statements, cqid=qid) is True
+
+
+def test_force_append_always_requires_write():
+    """
+    Regression: when all the submitted statements already existed on the item, FORCE_APPEND wrongly
+    reported that no write was required, so the forced duplicates were never written.
+    """
+    frc = FakeQueryDataAppendProps(base_filter=[BaseDataType(prop_nr='P352'), Item(prop_nr='P703', value='Q15978631')], base_data_type=BaseDataType)
+
+    statements = [Item(value='Q24784025', prop_nr='P527'), Item(value='Q24743729', prop_nr='P527'), Item(value='Q24782625', prop_nr='P527')]
+    assert frc.write_required(data=statements, action_if_exists=ActionIfExists.FORCE_APPEND, cqid='Q3402672') is True
+
+
+class FakeQueryDataDuplicateStatements(wbi_fastrun.FastRunContainer):
+    # an item holding twice the same value for P527, in two distinct statements
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.prop_dt_map = {'P527': 'wikibase-item'}
+
+        self.rev_lookup = defaultdict(set)
+        self.rev_lookup['Q24784025'].add('Q3402672')
+
+        self.prop_data['Q3402672'] = {'P527': {
+            'Q3402672-11BA231B-857B-498B-AC4F-91D71EE007FD': {'qual': set(), 'ref': {}, 'v': 'Q24784025'},
+            'Q3402672-15F54AFF-7DCC-4DF6-A32F-73C48619B0B2': {'qual': set(), 'ref': {}, 'v': 'Q24784025'}}}
+
+
+def test_append_with_duplicate_statements():
+    """
+    Regression: a new value missing from the item was masked by another value matching two duplicate
+    statements, so the append wrongly reported that no write was required.
+    """
+    frc = FakeQueryDataDuplicateStatements(base_filter=[BaseDataType(prop_nr='P352'), Item(prop_nr='P703', value='Q15978631')], base_data_type=BaseDataType)
+
+    # both values already exist (one of them twice): no write required
+    statements = [Item(value='Q24784025', prop_nr='P527')]
+    assert frc.write_required(data=statements, action_if_exists=ActionIfExists.APPEND_OR_REPLACE, cqid='Q3402672') is False
+
+    # one value exists twice, the other is new: a write is required
+    statements = [Item(value='Q24784025', prop_nr='P527'), Item(value='Q99999999', prop_nr='P527')]
+    assert frc.write_required(data=statements, action_if_exists=ActionIfExists.APPEND_OR_REPLACE, cqid='Q3402672') is True

--- a/test/test_wbi_fastrun.py
+++ b/test/test_wbi_fastrun.py
@@ -10,7 +10,7 @@ from typing import Any
 import pytest
 
 from wikibaseintegrator import WikibaseIntegrator, wbi_fastrun
-from wikibaseintegrator.datatypes import BaseDataType, ExternalID, Item, Quantity
+from wikibaseintegrator.datatypes import BaseDataType, ExternalID, GlobeCoordinate, Item, MonolingualText, Quantity, Time
 from wikibaseintegrator.entities import ItemEntity
 from wikibaseintegrator.wbi_enums import ActionIfExists
 
@@ -77,6 +77,47 @@ class TestQueryData:
         values = {statement['v'] for statement in frc.prop_data['Q99']['P2888'].values()}
         assert all(value.startswith('<http') for value in values)
 
+    def test_query_data_unit_normalization(self, wikibase):
+        """Unit URIs are reduced to entity IDs, and the unitless unit (always the Wikidata Q199 entity) to '1'."""
+        wikibase.add_property('P2067', 'quantity')
+        wikibase.add_property('P2068', 'quantity')
+
+        frc = wbi_fastrun.FastRunContainer(base_filter=[BaseDataType(prop_nr='P2067')], base_data_type=BaseDataType)
+
+        # unitless: the RDF always uses the Wikidata Q199 entity, even on another instance
+        bindings = statement_bindings(wikibase, 'Q99', 'P2067', [literal('42', datatype='http://www.w3.org/2001/XMLSchema#decimal')])
+        bindings[0]['unit'] = uri('http://www.wikidata.org/entity/Q199')
+        wikibase.sparql_bindings = bindings
+        frc._query_data('P2067', use_units=True)
+        assert list(frc.prop_data['Q99']['P2067'].values())[0]['unit'] == '1'
+
+        # a unit local to the instance is reduced to its entity ID
+        bindings = statement_bindings(wikibase, 'Q99', 'P2068', [literal('42', datatype='http://www.w3.org/2001/XMLSchema#decimal')])
+        bindings[0]['unit'] = uri(f'{wikibase.base_url}/entity/Q11573')
+        wikibase.sparql_bindings = bindings
+        frc._query_data('P2068', use_units=True)
+        assert list(frc.prop_data['Q99']['P2068'].values())[0]['unit'] == 'Q11573'
+
+    def test_query_data_monolingualtext_qualifier(self, wikibase):
+        """The language of monolingual text qualifiers must be kept, it is needed to reconstruct them."""
+        wikibase.add_property('P828', 'wikibase-item')
+        wikibase.add_property('P1476', 'monolingualtext')
+
+        frc = wbi_fastrun.FastRunContainer(base_filter=[BaseDataType(prop_nr='P828')], base_data_type=BaseDataType)
+
+        bindings = statement_bindings(wikibase, 'Q99', 'P828', [uri(f'{wikibase.base_url}/entity/Q2')])
+        bindings[0]['pq'] = uri(f'{wikibase.base_url}/prop/qualifier/P1476')
+        bindings[0]['qval'] = literal('Some title', lang='en')
+        wikibase.sparql_bindings = bindings
+        frc._query_data('P828')
+
+        statement = list(frc.prop_data['Q99']['P828'].values())[0]
+        assert ('P1476', '"Some title"@en', '1') in statement['qual']
+
+        # the reconstructed qualifier is comparable with a local MonolingualText qualifier
+        qualifier = MonolingualText(text='Some title', language='en', prop_nr='P1476')
+        assert frc.write_required(data=[Item(value='Q2', prop_nr='P828', qualifiers=[qualifier])]) is False
+
     def test_query_data_ref(self, wikibase):
         wikibase.add_property('P352', 'external-id')
         wikibase.add_property('P248', 'wikibase-item')
@@ -134,6 +175,21 @@ class TestWriteRequiredEndToEnd:
 
         assert frc.write_required(data=[Quantity(amount=42, prop_nr='P2067')]) is False
         assert frc.write_required(data=[Quantity(amount=43, prop_nr='P2067')]) is True
+
+    def test_write_required_quantity_unitless(self, wikibase):
+        """
+        Regression: the unitless unit URI (the Wikidata Q199 entity) was stored as-is instead of being normalized
+        to '1', so unitless quantities never matched the local claims and a write was always wrongly reported.
+        """
+        wikibase.add_property('P2067', 'quantity')
+        bindings = statement_bindings(wikibase, 'Q42', 'P2067', [literal('42', datatype='http://www.w3.org/2001/XMLSchema#decimal')])
+        bindings[0]['unit'] = uri('http://www.wikidata.org/entity/Q199')
+        wikibase.sparql_bindings = bindings
+
+        frc = wbi_fastrun.FastRunContainer(base_filter=[BaseDataType(prop_nr='P2067')], base_data_type=BaseDataType)
+
+        assert frc.write_required(data=[Quantity(amount=42, prop_nr='P2067')]) is False
+        assert frc.write_required(data=[Quantity(amount=42, unit='Q11573', prop_nr='P2067')]) is True
 
     def test_write_required_with_property_path_base_filter(self, wikibase, item_q582):
         """
@@ -340,6 +396,58 @@ def test_write_required_case_sensitive_by_default():
 
     assert frc.write_required(data=[ExternalID(value='Q9UMX9', prop_nr='P352')]) is True
     assert frc.write_required(data=[ExternalID(value='q9umx9', prop_nr='P352')]) is False
+
+
+def test_normalize_unit():
+    frc = wbi_fastrun.FastRunContainer(base_filter=[BaseDataType(prop_nr='P352')], base_data_type=BaseDataType, wikibase_url='http://www.wikidata.org')
+
+    # the unitless unit is always the Wikidata Q199 entity, even when it is local to the instance
+    assert frc._normalize_unit('http://www.wikidata.org/entity/Q199') == '1'
+    # a unit local to the instance is reduced to its entity ID
+    assert frc._normalize_unit('http://www.wikidata.org/entity/Q11573') == 'Q11573'
+    # a unit from another instance is kept as-is
+    assert frc._normalize_unit('https://wikibase.example.org/entity/Q5') == 'https://wikibase.example.org/entity/Q5'
+
+
+class FastRunContainerFakeQueryDataQualifiers(wbi_fastrun.FastRunContainer):
+    # an item with one statement carrying qualifiers of the datatypes needing a dedicated reconstruction
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.prop_dt_map = {'P527': 'wikibase-item', 'P1114': 'quantity', 'P585': 'time', 'P1476': 'monolingualtext', 'P625': 'globe-coordinate'}
+        self.rev_lookup = defaultdict(set)
+        self.rev_lookup['Q2'].add('Q1')
+        self.prop_data['Q1'] = {'P527': {
+            'fake statement id': {
+                'qual': {
+                    ('P1114', '+12', '1'),
+                    ('P585', '+2020-02-08T00:00:00Z', '1'),
+                    ('P1476', '"Some title"@en', '1'),
+                    ('P625', 'Point(2.35 48.85)', '1'),
+                },
+                'ref': {},
+                'unit': '1',
+                'v': 'Q2'}}}
+
+
+def test_write_required_with_qualifier_datatypes():
+    """
+    Regression: reconstructing quantity, time, monolingual text or globe coordinate qualifiers crashed with a
+    TypeError because those datatype constructors do not accept a generic 'value' parameter.
+    """
+    frc = FastRunContainerFakeQueryDataQualifiers(base_filter=[BaseDataType(prop_nr='P527')], base_data_type=BaseDataType)
+
+    qualifiers = [
+        Quantity(amount=12, prop_nr='P1114'),
+        Time(time='+2020-02-08T00:00:00Z', prop_nr='P585'),
+        MonolingualText(text='Some title', language='en', prop_nr='P1476'),
+        GlobeCoordinate(latitude=48.85, longitude=2.35, prop_nr='P625'),
+    ]
+    # same qualifiers: no write required
+    assert frc.write_required(data=[Item(value='Q2', prop_nr='P527', qualifiers=list(qualifiers))]) is False
+
+    # a differing qualifier value: write required
+    qualifiers[0] = Quantity(amount=13, prop_nr='P1114')
+    assert frc.write_required(data=[Item(value='Q2', prop_nr='P527', qualifiers=list(qualifiers))]) is True
 
 
 class FakeQueryDataAppendProps(wbi_fastrun.FastRunContainer):

--- a/wikibaseintegrator/datatypes/time.py
+++ b/wikibaseintegrator/datatypes/time.py
@@ -105,6 +105,21 @@ class Time(BaseDataType):
     def get_sparql_value(self) -> str:
         return self.mainsnak.datavalue['value']['time']
 
+    def parse_sparql_value(self, value, type='literal', unit='1') -> bool:
+        pattern = re.compile(r'^"?([+-]?[0-9]{1,16}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)"?(?:\^\^xsd:dateTime)?$')
+        matches = pattern.match(value)
+        if not matches:
+            return False
+
+        try:
+            # The RDF value does not carry the precision, set_value() infers it from the timestamp
+            self.set_value(time=matches.group(1))
+        except ValueError:
+            # The precision cannot be inferred (e.g. a timestamp with a time part), set_value() cannot represent it
+            return False
+
+        return True
+
     def _time_parts(self) -> tuple[int, int, int]:
         """
         Split the timestamp into (year, month, day).

--- a/wikibaseintegrator/wbi_fastrun.py
+++ b/wikibaseintegrator/wbi_fastrun.py
@@ -61,6 +61,18 @@ class FastRunContainer:
                 else:
                     raise ValueError("base_filter must be an instance of BaseDataType or a list of instances of BaseDataType")
 
+    def _get_datatype_class(self, datatype: str | None) -> type[BaseDataType]:
+        """
+        Return the data type class implementing the given Wikibase datatype (e.g. 'external-id' -> ExternalID).
+
+        :param datatype: A Wikibase datatype name
+        :exception ValueError: if no class implements the given datatype
+        """
+        for subclass in self.base_data_type.subclasses:
+            if subclass.DTYPE == datatype:
+                return subclass
+        raise ValueError(f"No data type class found for datatype '{datatype}'")
+
     def reconstruct_statements(self, qid: str) -> list[BaseDataType]:
         reconstructed_statements: list[BaseDataType] = []
 
@@ -80,7 +92,7 @@ class FastRunContainer:
             for _, d in dt.items():
                 qualifiers = []
                 for q in d['qual']:
-                    f = [x for x in self.base_data_type.subclasses if x.DTYPE == self.prop_dt_map[q[0]]][0]
+                    f = self._get_datatype_class(self.prop_dt_map[q[0]])
                     # TODO: Add support for more data type (Time, MonolingualText, GlobeCoordinate)
                     if self.prop_dt_map[q[0]] == 'quantity':
                         qualifiers.append(f(value=q[1], prop_nr=q[0], unit=q[2]))
@@ -91,11 +103,11 @@ class FastRunContainer:
                 for _, refs in d['ref'].items():
                     this_ref = []
                     for ref in refs:
-                        f = [x for x in self.base_data_type.subclasses if x.DTYPE == self.prop_dt_map[ref[0]]][0]
+                        f = self._get_datatype_class(self.prop_dt_map[ref[0]])
                         this_ref.append(f(value=ref[1], prop_nr=ref[0]))
                     references.append(this_ref)
 
-                f = [x for x in self.base_data_type.subclasses if x.DTYPE == self.prop_dt_map[prop_nr]][0]
+                f = self._get_datatype_class(self.prop_dt_map[prop_nr])
                 # TODO: Add support for more data type
                 if self.prop_dt_map[prop_nr] == 'quantity':
                     datatype = f(prop_nr=prop_nr, qualifiers=qualifiers, references=references, unit=d['unit'])
@@ -114,9 +126,8 @@ class FastRunContainer:
         Get items ID from a SPARQL endpoint
 
         :param claims: A list of claims the entities should have
-        :param cqid:
-        :return: a list of entity ID or None
-        :exception: if there is more than one claim
+        :param cqid: If given, this entity ID is returned instead of the IDs found by the value lookup
+        :return: a set of entity IDs or None if no entity matches the claims
         """
         match_sets = []
 
@@ -127,7 +138,7 @@ class FastRunContainer:
 
         for claim in claims:
             # skip to next if statement has no value or no data type defined, e.g. for deletion objects
-            if not claim.mainsnak.datavalue and not claim.mainsnak.datatype:
+            if not claim.mainsnak.datavalue or not claim.mainsnak.datatype:
                 continue
 
             prop_nr = claim.mainsnak.property_number
@@ -141,18 +152,16 @@ class FastRunContainer:
                     self.prop_dt_map.update({prop_nr: self.get_prop_datatype(prop_nr)})
                 self._query_data(prop_nr=prop_nr, use_units=self.prop_dt_map[prop_nr] == 'quantity')
 
-            # noinspection PyProtectedMember
-            current_value = claim.get_sparql_value()
-
+            # The value must be formatted the same way as the rev_lookup keys built in format_query_results()
             if self.prop_dt_map[prop_nr] == 'wikibase-item':
                 current_value = claim.mainsnak.datavalue['value']['id']
+            elif self.prop_dt_map[prop_nr] == 'quantity':
+                # rev_lookup stores plain amounts (e.g. '+42'), not the full SPARQL literal returned by get_sparql_value()
+                current_value = format_amount(claim.mainsnak.datavalue['value']['amount'])
+            else:
+                current_value = claim.get_sparql_value()
 
             log.debug(current_value)
-            # if self.case_insensitive:
-            #     log.debug("case insensitive enabled")
-            #     log.debug(self.rev_lookup_ci)
-            # else:
-            #     log.debug(self.rev_lookup)
 
             if current_value in self.rev_lookup:
                 # quick check for if the value has ever been seen before, if not, write required
@@ -202,11 +211,15 @@ class FastRunContainer:
         :param cqid:
         :return: Return True if the write is required
         """
-        del_props = set()
         data_props = set()
-        append_props = []
-        if action_if_exists == ActionIfExists.APPEND_OR_REPLACE:
+        append_props: list[str] = []
+        if action_if_exists in (ActionIfExists.APPEND_OR_REPLACE, ActionIfExists.FORCE_APPEND):
             append_props = [x.mainsnak.property_number for x in data]
+
+        if append_props and action_if_exists == ActionIfExists.FORCE_APPEND:
+            # The new statements are always appended, so a write is always required
+            log.debug("force append: write required")
+            return True
 
         for x in data:
             if x.mainsnak.datavalue and x.mainsnak.datatype:
@@ -219,67 +232,48 @@ class FastRunContainer:
         reconstructed_statements = self.reconstruct_statements(qid)
         tmp_rs = copy.deepcopy(reconstructed_statements)
 
-        # handle append properties
-        for p in append_props:
+        # handle append properties: every new statement must already exist on the item with the same value
+        # (and the same references if use_refs is enabled), otherwise a write is required
+        for p in set(append_props):
             app_data = [x for x in data if x.mainsnak.property_number == p]  # new statements
             rec_app_data = [x for x in tmp_rs if x.mainsnak.property_number == p]  # orig statements
-            comp = []
-            for x in app_data:
-                for y in rec_app_data:
-                    if x.mainsnak.datavalue == y.mainsnak.datavalue:
-                        if y.equals(x, include_ref=self.use_refs) and action_if_exists != ActionIfExists.FORCE_APPEND:
-                            comp.append(True)
-
-            # comp = [True for x in app_data for y in rec_app_data if x.equals(y, include_ref=self.use_refs)]
-            if len(comp) != len(app_data):
-                log.debug("failed append: %s", p)
-                return True
+            for new_statement in app_data:
+                if not any(original.mainsnak.datavalue == new_statement.mainsnak.datavalue and original.equals(new_statement, include_ref=self.use_refs)
+                           for original in rec_app_data):
+                    log.debug("failed append: %s", p)
+                    return True
 
         tmp_rs = [x for x in tmp_rs if x.mainsnak.property_number not in append_props and x.mainsnak.property_number in data_props]
 
-        for date in data:
+        for statement in data:
             # ensure that statements meant for deletion get handled properly
             reconst_props = {x.mainsnak.property_number for x in tmp_rs}
-            if not date.mainsnak.datatype and date.mainsnak.property_number in reconst_props:
+            if not statement.mainsnak.datatype and statement.mainsnak.property_number in reconst_props:
                 log.debug("returned from delete prop handling")
                 return True
 
-            if not date.mainsnak.datavalue or not date.mainsnak.datatype:
+            if not statement.mainsnak.datavalue or not statement.mainsnak.datatype:
                 # Ignore the deletion statements which are not in the reconstructed statements.
                 continue
 
-            if date.mainsnak.property_number in append_props:
-                # TODO: check if value already exist and already have the same value
+            if statement.mainsnak.property_number in append_props:
                 continue
 
-            if not date.mainsnak.datavalue and not date.mainsnak.datatype:
-                del_props.add(date.mainsnak.property_number)
-
             # this is where the magic happens
-            # date is a new statement, proposed to be written
+            # statement is a new statement, proposed to be written
             # tmp_rs are the reconstructed statements == current state of the item
-            bool_vec = []
-            for x in tmp_rs:
-                if (x == date or (self.case_insensitive and x.mainsnak.datavalue.casefold() == date.mainsnak.datavalue.casefold())) and x.mainsnak.property_number not in del_props:
-                    bool_vec.append(x.equals(date, include_ref=self.use_refs))
-                else:
-                    bool_vec.append(False)
-            # bool_vec = [x.equals(date, include_ref=self.use_refs, fref=self.ref_comparison_f) and
-            # x.mainsnak.property_number not in del_props for x in tmp_rs]
+            bool_vec = [self._statements_equal(x, statement) for x in tmp_rs]
 
-            log.debug("bool_vec: %s", bool_vec)
-            log.debug("-----------------------------------")
-            for x in tmp_rs:
-                if x == date and x.mainsnak.property_number not in del_props:
-                    log.debug([x.mainsnak.property_number, x.mainsnak.datavalue, [z.datavalue for z in x.qualifiers]])
-                    log.debug([date.mainsnak.property_number, date.mainsnak.datavalue, [z.datavalue for z in date.qualifiers]])
-                elif x.mainsnak.property_number == date.mainsnak.property_number:
-                    log.debug([x.mainsnak.property_number, x.mainsnak.datavalue, [z.datavalue for z in x.qualifiers]])
-                    log.debug([date.mainsnak.property_number, date.mainsnak.datavalue, [z.datavalue for z in date.qualifiers]])
+            if log.isEnabledFor(logging.DEBUG):
+                log.debug("bool_vec: %s", bool_vec)
+                log.debug("-----------------------------------")
+                for x in tmp_rs:
+                    if x.mainsnak.property_number == statement.mainsnak.property_number:
+                        log.debug([x.mainsnak.property_number, x.mainsnak.datavalue, [z.datavalue for z in x.qualifiers]])
+                        log.debug([statement.mainsnak.property_number, statement.mainsnak.datavalue, [z.datavalue for z in statement.qualifiers]])
 
             if not any(bool_vec):
-                log.debug(len(bool_vec))
-                log.debug("fast run failed at %s", date.mainsnak.property_number)
+                log.debug("fast run failed at %s (%s candidate statements)", statement.mainsnak.property_number, len(bool_vec))
                 return True
 
             log.debug("fast run success")
@@ -293,6 +287,31 @@ class FastRunContainer:
             return True
 
         return False
+
+    def _statements_equal(self, statement: BaseDataType, new_statement: Claim) -> bool:
+        """
+        Compare a reconstructed statement with a new statement, including the references if use_refs is enabled.
+        When case_insensitive is enabled, string values differing only by case are considered equal.
+
+        :param statement: A statement reconstructed from the SPARQL data (the current state of the entity)
+        :param new_statement: The statement proposed to be written
+        :return: True if both statements are considered equal
+        """
+        if statement.equals(new_statement, include_ref=self.use_refs):
+            return True
+
+        if not self.case_insensitive or statement.mainsnak.property_number != new_statement.mainsnak.property_number:
+            return False
+
+        current_value = (statement.mainsnak.datavalue or {}).get('value')
+        new_value = (new_statement.mainsnak.datavalue or {}).get('value')
+        if not isinstance(current_value, str) or not isinstance(new_value, str) or current_value.casefold() != new_value.casefold():
+            return False
+
+        if not statement.has_equal_qualifiers(new_statement):
+            return False
+
+        return not self.use_refs or Claim.refs_equal(statement, new_statement)
 
     def init_language_data(self, lang: str, lang_data_type: str) -> None:
         """
@@ -404,10 +423,10 @@ class FastRunContainer:
                 elif i['v']['type'] == 'literal' and prop_dt == 'quantity':
                     i['v'] = format_amount(i['v']['value'])
                 elif i['v']['type'] == 'literal' and prop_dt == 'monolingualtext':
-                    f = [x for x in self.base_data_type.subclasses if x.DTYPE == prop_dt][0](prop_nr=prop_nr, text=i['v']['value'], language=i['v']['xml:lang'])
+                    f = self._get_datatype_class(prop_dt)(prop_nr=prop_nr, text=i['v']['value'], language=i['v']['xml:lang'])
                     i['v'] = f.get_sparql_value()
                 else:
-                    f = [x for x in self.base_data_type.subclasses if x.DTYPE == prop_dt][0](prop_nr=prop_nr)
+                    f = self._get_datatype_class(prop_dt)(prop_nr=prop_nr)
                     if not f.parse_sparql_value(value=i['v']['value'], type=i['v']['type']):
                         raise ValueError("Can't parse the value with parse_sparql_value()")
                     i['v'] = f.get_sparql_value()
@@ -570,7 +589,7 @@ class FastRunContainer:
             self.update_frc_from_query(results, prop_nr)
             page_count += 1
 
-            if len(results) == 0 or len(results) < page_size:
+            if len(results) < page_size:
                 break
 
     def _query_lang(self, lang: str, lang_data_type: str) -> list[dict[str, dict]] | None:
@@ -631,6 +650,7 @@ class FastRunContainer:
         self.prop_data = {}
         self.rev_lookup = defaultdict(set)
         self.rev_lookup_ci = defaultdict(set)
+        self.loaded_langs = {}
 
     def __repr__(self) -> str:
         """A mixin implementing a simple __repr__."""

--- a/wikibaseintegrator/wbi_fastrun.py
+++ b/wikibaseintegrator/wbi_fastrun.py
@@ -20,6 +20,10 @@ log = logging.getLogger(__name__)
 
 fastrun_store: list[FastRunContainer] = []
 
+# The RDF export of a Wikibase instance always represents a quantity without a unit ('1' in the JSON representation)
+# with the Wikidata entity Q199 (the number one), whatever the instance.
+UNITLESS_UNIT_URI = 'http://www.wikidata.org/entity/Q199'
+
 
 class FastRunContainer:
     def __init__(self, base_data_type: type[BaseDataType], mediawiki_api_url: str | None = None, sparql_endpoint_url: str | None = None, wikibase_url: str | None = None,
@@ -73,6 +77,20 @@ class FastRunContainer:
                 return subclass
         raise ValueError(f"No data type class found for datatype '{datatype}'")
 
+    def _reconstruct_snak_datatype(self, prop_nr: str, value: str, unit: str = '1') -> BaseDataType:
+        """
+        Rebuild a datatype object from the raw SPARQL value stored in prop_data, used for qualifiers and references.
+
+        :param prop_nr: The property number of the snak
+        :param value: The raw SPARQL value
+        :param unit: The unit entity ID if the value is a quantity
+        :exception ValueError: if the value can't be parsed by the datatype class
+        """
+        datatype = self._get_datatype_class(self.prop_dt_map[prop_nr])(prop_nr=prop_nr)
+        if not datatype.parse_sparql_value(value=value, unit=unit):
+            raise ValueError(f"Can't parse the value '{value}' of property {prop_nr} with parse_sparql_value()")
+        return datatype
+
     def reconstruct_statements(self, qid: str) -> list[BaseDataType]:
         reconstructed_statements: list[BaseDataType] = []
 
@@ -89,32 +107,20 @@ class FastRunContainer:
                 if prop not in self.prop_dt_map:
                     self.prop_dt_map.update({prop: self.get_prop_datatype(prop)})
             # reconstruct statements from frc (including unit, qualifiers, and refs)
+            # Note: attributes missing from the SPARQL simple values (time precision, globe coordinate precision,
+            # quantity bounds...) are rebuilt with their default value, so statements using non-default attributes
+            # are always reported as requiring a write.
             for _, d in dt.items():
-                qualifiers = []
-                for q in d['qual']:
-                    f = self._get_datatype_class(self.prop_dt_map[q[0]])
-                    # TODO: Add support for more data type (Time, MonolingualText, GlobeCoordinate)
-                    if self.prop_dt_map[q[0]] == 'quantity':
-                        qualifiers.append(f(value=q[1], prop_nr=q[0], unit=q[2]))
-                    else:
-                        qualifiers.append(f(value=q[1], prop_nr=q[0]))
+                qualifiers = [self._reconstruct_snak_datatype(prop_nr=q[0], value=q[1], unit=q[2]) for q in d['qual']]
 
                 references = []
                 for _, refs in d['ref'].items():
-                    this_ref = []
-                    for ref in refs:
-                        f = self._get_datatype_class(self.prop_dt_map[ref[0]])
-                        this_ref.append(f(value=ref[1], prop_nr=ref[0]))
-                    references.append(this_ref)
+                    references.append([self._reconstruct_snak_datatype(prop_nr=ref[0], value=ref[1]) for ref in refs])
 
                 f = self._get_datatype_class(self.prop_dt_map[prop_nr])
-                # TODO: Add support for more data type
-                if self.prop_dt_map[prop_nr] == 'quantity':
-                    datatype = f(prop_nr=prop_nr, qualifiers=qualifiers, references=references, unit=d['unit'])
-                    datatype.parse_sparql_value(value=d['v'], unit=d['unit'])
-                else:
-                    datatype = f(prop_nr=prop_nr, qualifiers=qualifiers, references=references)
-                    datatype.parse_sparql_value(value=d['v'])
+                datatype = f(prop_nr=prop_nr, qualifiers=qualifiers, references=references)
+                if not datatype.parse_sparql_value(value=d['v'], unit=d.get('unit', '1')):
+                    raise ValueError(f"Can't parse the value '{d['v']}' of property {prop_nr} with parse_sparql_value()")
                 reconstructed_statements.append(datatype)
 
         # this isn't used. done for debugging purposes
@@ -376,6 +382,20 @@ class FastRunContainer:
     def get_all_data(self) -> dict[str, dict]:
         return self.prop_data
 
+    def _normalize_unit(self, unit_uri: str) -> str:
+        """
+        Normalize a unit URI from the SPARQL results to the format used in the JSON representation: the entity ID for
+        the units local to the instance, and '1' for unitless quantities, which the RDF export always represents with
+        the Wikidata entity Q199, whatever the Wikibase instance.
+
+        :param unit_uri: The unit URI from the SPARQL results
+        """
+        if unit_uri == UNITLESS_UNIT_URI:
+            return '1'
+        if unit_uri.startswith(self.wikibase_url):
+            return unit_uri.split('/')[-1]
+        return unit_uri
+
     def format_query_results(self, r: list, prop_nr: str) -> None:
         """
         `r` is the results of the sparql query in _query_data and is modified in place
@@ -395,16 +415,17 @@ class FastRunContainer:
         """
         prop_dt = self.get_prop_datatype(prop_nr)
         for i in r:
-            for value in ['item', 'sid', 'pq', 'pr', 'ref', 'unit', 'qunit']:
+            for value in ['item', 'sid', 'pq', 'pr', 'ref']:
                 if value in i:
                     if i[value]['value'].startswith(self.wikibase_url):
                         i[value] = i[value]['value'].split('/')[-1]
                     else:
-                        # TODO: Dirty fix. If we are not on wikidata, we force unitless (Q199) to '1'
-                        if i[value]['value'] == 'http://www.wikidata.org/entity/Q199':
-                            i[value] = '1'
-                        else:
-                            i[value] = i[value]['value']
+                        i[value] = i[value]['value']
+
+            # normalize the unit URIs to entity IDs and the unitless unit to '1'
+            for value in ['unit', 'qunit']:
+                if value in i:
+                    i[value] = self._normalize_unit(i[value]['value'])
 
             # make sure datetimes are formatted correctly.
             # the correct format is '+%Y-%m-%dT%H:%M:%SZ', but is sometimes missing the plus??
@@ -445,6 +466,9 @@ class FastRunContainer:
                     i['qval'] = i['qval']['value'].split('/')[-1]
                 elif i['qval']['type'] == 'literal' and qual_prop_dt == 'quantity':
                     i['qval'] = format_amount(i['qval']['value'])
+                elif i['qval']['type'] == 'literal' and qual_prop_dt == 'monolingualtext' and 'xml:lang' in i['qval']:
+                    # keep the language, it is needed to reconstruct the qualifier
+                    i['qval'] = self._get_datatype_class(qual_prop_dt)(prop_nr=i['pq'], text=i['qval']['value'], language=i['qval']['xml:lang']).get_sparql_value()
                 else:
                     i['qval'] = i['qval']['value']
 
@@ -455,6 +479,9 @@ class FastRunContainer:
                     i['rval'] = i['rval']['value'].split('/')[-1]
                 elif i['rval']['type'] == 'literal' and ref_prop_dt == 'quantity':
                     i['rval'] = format_amount(i['rval']['value'])
+                elif i['rval']['type'] == 'literal' and ref_prop_dt == 'monolingualtext' and 'xml:lang' in i['rval']:
+                    # keep the language, it is needed to reconstruct the reference
+                    i['rval'] = self._get_datatype_class(ref_prop_dt)(prop_nr=i['pr'], text=i['rval']['value'], language=i['rval']['xml:lang']).get_sparql_value()
                 else:
                     i['rval'] = i['rval']['value']
 


### PR DESCRIPTION
## Summary

This PR fixes several long-standing bugs in `wbi_fastrun.py`, resolves the three TODOs of the module, and rewrites the outdated fast run section of the README. Every fix comes with a regression test; the offline test suite grows from 203 to 215 tests.

## Bug fixes in `write_required()` / `get_items()`

* **Append mode could silently skip a required write**: a new value missing from the item was masked by another value matching two duplicate statements (`len(comp)` counted matching *pairs*, not matched statements). Each new statement must now individually exist on the item.
* **`FORCE_APPEND` now always reports a write**: previously, when all the submitted statements already existed, the forced append was silently skipped.
* **`case_insensitive` mode crashed** with an `AttributeError` (`datavalue` is a dict, not a string) and could never match values differing by case. The comparison is now handled by `_statements_equal()`, which compares string values casefolded together with qualifiers (and references when `use_refs` is enabled).
* **Deletion objects (value-less claims) crashed `get_items()`** with a `KeyError`: the skip condition used `and` where the intent (and the equivalent code in `write_required()`) was `or`.
* **Quantity properties never matched**: `get_items()` looked up the full SPARQL literal (`"+42"^^xsd:decimal`) while `rev_lookup` stores plain amounts (`+42`), so a write was always wrongly reported.
* **Unitless quantities never matched**: the RDF export represents a unitless quantity with the Wikidata `Q199` entity whatever the instance (verified against WDQS), while the JSON representation uses `'1'`. The unit URIs are now normalized by a dedicated `_normalize_unit()` method, replacing the previous "dirty fix" that only covered non-Wikidata instances.

## TODO resolutions

* **Qualifier/reference reconstruction now supports every datatype**: qualifiers and references are rebuilt with `parse_sparql_value()` instead of passing a generic `value` to constructors that do not all accept it (quantity qualifiers crashed with a `TypeError`).
* **`Time.parse_sparql_value()` added**: time values crashed the generic parsing path (`Time.set_value()` has no `value` parameter). The precision is inferred from the timestamp.
* **Monolingual text qualifiers and references keep their language** in `format_query_results()`, so they can be reconstructed and compared.
* The remaining limitation (attributes absent from the SPARQL simple values: time precision, globe coordinate precision, quantity bounds) is documented in the code and the README instead of a TODO.

## Cleanups

* Remove the dead `del_props` handling and the unreachable `FORCE_APPEND` condition
* Raise a clear `ValueError` instead of an `IndexError` when no datatype class matches
* `clear()` also resets the language data cache
* Debug-only loops only run when DEBUG logging is enabled

## Documentation

The "Examples (in fast run mode)" section of the README still documented the WikidataIntegrator API (`fast_run=True`, `fast_run_base_filter` as a dictionary, `init_fastrun()`). It is rewritten around the current API: `entity.write_required()` and its options, the three base filter forms (including property paths), the fact that only the claims whose property appears in the base filter are compared, label/description/aliases checking through the fastrun container, and the limitations.

## Test plan

- [x] `pytest test/` — 215 passed (12 new regression tests)
- [x] `mypy` — no issues on the modified files
- [x] Unitless unit representation verified against the live Wikidata Query Service

🤖 Generated with [Claude Code](https://claude.com/claude-code)
