### PR TITLE
Fix mypy errors in reauthenticate() and run lint on dependency bumps

### DIFF
--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -6,11 +6,15 @@ on:
     paths:
       - 'wikibaseintegrator/**.py'
       - 'test/**.py'
+      - 'pyproject.toml'
+      - 'poetry.lock'
   pull_request:
     branches: [ '**' ]
     paths:
       - 'wikibaseintegrator/**.py'
       - 'test/**.py'
+      - 'pyproject.toml'
+      - 'poetry.lock'
 
 jobs:
   build:

--- a/wikibaseintegrator/wbi_login.py
+++ b/wikibaseintegrator/wbi_login.py
@@ -335,7 +335,8 @@ class Login(_Login):
         See _Login.reauthenticate() for why this full re-login is needed instead of just fetching a new token.
         """
         log.warning("Session no longer valid, re-authenticating as %s", self._user)
-        headers = {'User-Agent': self.session.headers.get('User-Agent', get_user_agent())}
+        session_user_agent = self.session.headers.get('User-Agent')
+        headers = {'User-Agent': session_user_agent if isinstance(session_user_agent, str) else get_user_agent()}
         self._perform_login(session=self.session, mediawiki_api_url=self.mediawiki_api_url, headers=headers, **self._login_kwargs)
         self.generate_edit_credentials()
         self.instantiation_time = time.time()
@@ -424,7 +425,8 @@ class Clientlogin(_Login):
         See _Login.reauthenticate() for why this full re-login is needed instead of just fetching a new token.
         """
         log.warning("Session no longer valid, re-authenticating as %s", self._user)
-        headers = {'User-Agent': self.session.headers.get('User-Agent', get_user_agent())}
+        session_user_agent = self.session.headers.get('User-Agent')
+        headers = {'User-Agent': session_user_agent if isinstance(session_user_agent, str) else get_user_agent()}
         self._perform_login(session=self.session, mediawiki_api_url=self.mediawiki_api_url, headers=headers, **self._login_kwargs)
         self.generate_edit_credentials()
         self.instantiation_time = time.time()


### PR DESCRIPTION
The mypy 2.3.0 bump (#1006) introduced two errors in wbi_login.py: session.headers.get() returns str | bytes, which is incompatible with the dict[str, str] expected by _perform_login(). Guard the value with an isinstance check before building the headers.

The errors went unnoticed because python-lint.yaml only triggers on **.py changes: dependency bumps that touch pyproject.toml/poetry.lock merged without running the linters. Add both files to the workflow paths, matching python-pytest.yaml.

Also bump actions/setup-python to v7.0.0 in the lint workflow.