### PR TITLE
Fix outdated fastrun claim in README and version note in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,4 +92,4 @@ notebooks/                  # Jupyter usage examples
 - `wbi_config.py` holds the default `mediawiki_api_url` (`https://www.wikidata.org/w/api.php`). Unit tests must never hit a real API: use the `wikibase` fixture (MockWikibase) or `requests_mock` directly; real-instance scenarios belong in `test/integration/`.
 - The `fastrun` module caches entity data before bulk writes to avoid redundant API calls — changes there require careful testing to avoid stale cache issues.
 - `datatypes/extra/` contains optional extensions with their own dependencies; do not import them unconditionally from core modules.
-- Version string is in `pyproject.toml` (`version = "0.12.16.dev0"`) and mirrored in `wikibaseintegrator/__init__.py`.
+- Version string is in `pyproject.toml` (`version = "0.12.16.dev0"`); `wikibaseintegrator/__init__.py` exposes it as `__version__` by reading the installed package metadata (`importlib.metadata`), so there is nothing to update there.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ The main differences between these two libraries are :
 * Add OAuth 2.0 login method
 * Add logging module support
 
-But WikibaseIntegrator lack the "fastrun" functionality implemented in WikidataIntegrator.
+WikibaseIntegrator also provides a rewritten version of the "fast run" mode of WikidataIntegrator, which avoids
+unnecessary API writes (see [Examples (in "fast run" mode)](#examples-in-fast-run-mode)).
 
 # Documentation #
 


### PR DESCRIPTION
The README still claimed WikibaseIntegrator lacks the fastrun functionality of WikidataIntegrator, while wbi_fastrun.py exists and is documented later in the same file. Replace the sentence with the same wording as PR #1001 so both branches merge cleanly.

AGENTS.md said the version string is mirrored in __init__.py, but it is now read from the installed package metadata via importlib.metadata.