### PR TITLE
Ignore local TODO.md and review notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ fabric.properties
 # Other stuff
 /drafts/
 /.run/
+
+# Local review notes, not to be pushed
+/TODO.md


### PR DESCRIPTION
Update .gitignore to exclude local review notes by adding a comment and /TODO.md at the repository root. This prevents accidentally committing personal review files; no functional code changes.